### PR TITLE
Use "type: integer" for int attributes, pagination, and http status codes

### DIFF
--- a/models/complex-resource/swagger.expected
+++ b/models/complex-resource/swagger.expected
@@ -32,7 +32,7 @@ paths:
                 properties:
                   id:
                     description: ''
-                    type: number
+                    type: integer
     get:
       tags:
         - Car
@@ -43,7 +43,7 @@ paths:
           name: offset
           description: Offset of the record (starting from 0) to include in the response.
           schema:
-            type: number
+            type: integer
             default: 0
         - in: query
           name: limit
@@ -51,7 +51,7 @@ paths:
             Number of records to return. If unspecified, 10 records will be
             returned. Maximum value for limit can be 100
           schema:
-            type: number
+            type: integer
             default: 10
             maximum: 100
         - in: query
@@ -59,7 +59,7 @@ paths:
           description: ''
           required: false
           schema:
-            type: number
+            type: integer
         - in: query
           name: brand
           description: ''
@@ -76,7 +76,7 @@ paths:
             X-Total-Count:
               description: Total number of records in the data set.
               schema:
-                type: number
+                type: integer
           content:
             application/json:
               schema:
@@ -100,7 +100,7 @@ paths:
           required: true
           description: ''
           schema:
-            type: number
+            type: integer
   '/v1/cars/{parentId}/wheels':
     post:
       tags:
@@ -122,14 +122,14 @@ paths:
                 properties:
                   id:
                     description: ''
-                    type: number
+                    type: integer
       parameters:
         - in: path
           name: parentId
           description: Id of parent Car
           required: true
           schema:
-            type: number
+            type: integer
     get:
       tags:
         - Car / Wheel
@@ -140,7 +140,7 @@ paths:
           name: offset
           description: Offset of the record (starting from 0) to include in the response.
           schema:
-            type: number
+            type: integer
             default: 0
         - in: query
           name: limit
@@ -148,7 +148,7 @@ paths:
             Number of records to return. If unspecified, 10 records will be
             returned. Maximum value for limit can be 100
           schema:
-            type: number
+            type: integer
             default: 10
             maximum: 100
         - in: query
@@ -156,13 +156,13 @@ paths:
           description: ''
           required: false
           schema:
-            type: number
+            type: integer
         - in: path
           name: parentId
           description: Id of parent Car
           required: true
           schema:
-            type: number
+            type: integer
       responses:
         '200':
           description: Wheels retrieved successfully
@@ -170,7 +170,7 @@ paths:
             X-Total-Count:
               description: Total number of records in the data set.
               schema:
-                type: number
+                type: integer
           content:
             application/json:
               schema:
@@ -194,13 +194,13 @@ paths:
           required: true
           description: ''
           schema:
-            type: number
+            type: integer
         - in: path
           name: parentId
           description: Id of parent Car
           required: true
           schema:
-            type: number
+            type: integer
     put:
       tags:
         - Car / Wheel
@@ -215,13 +215,13 @@ paths:
           required: true
           description: ''
           schema:
-            type: number
+            type: integer
         - in: path
           name: parentId
           description: Id of parent Car
           required: true
           schema:
-            type: number
+            type: integer
 components:
   parameters: {}
   schemas:
@@ -271,7 +271,7 @@ components:
       properties:
         id:
           description: ''
-          type: number
+          type: integer
         bought:
           description: ''
           type: string
@@ -342,7 +342,7 @@ components:
       properties:
         id:
           description: ''
-          type: number
+          type: integer
         radius:
           description: ''
           type: number
@@ -362,7 +362,7 @@ components:
       type: object
       properties:
         httpStatusCode:
-          type: number
+          type: integer
           description: The integer HTTP error status code for this problem
         errorCode:
           type: string
@@ -370,4 +370,3 @@ components:
         message:
           type: string
           description: Human readable error message
-

--- a/models/direct2dist/swagger.expected
+++ b/models/direct2dist/swagger.expected
@@ -58,7 +58,7 @@ paths:
           name: offset
           description: Offset of the record (starting from 0) to include in the response.
           schema:
-            type: number
+            type: integer
             default: 0
         - in: query
           name: limit
@@ -66,7 +66,7 @@ paths:
             Number of records to return. If unspecified, 10 records will be
             returned. Maximum value for limit can be 100
           schema:
-            type: number
+            type: integer
             default: 10
             maximum: 100
         - in: query
@@ -174,7 +174,7 @@ paths:
             X-Total-Count:
               description: Total number of records in the data set.
               schema:
-                type: number
+                type: integer
           content:
             application/json:
               schema:
@@ -284,7 +284,7 @@ components:
           description: >-
             Reference to a destination's endpoints to be used for distributing
             the data
-          type: number
+          type: integer
           example: >-
             Link to a Destination--Endpoint (to be defined in the future)
             resource via its id
@@ -359,7 +359,7 @@ components:
           description: >-
             Reference to a destination's endpoints to be used for distributing
             the data
-          type: number
+          type: integer
           example: >-
             Link to a Destination--Endpoint (to be defined in the future)
             resource via its id
@@ -492,10 +492,10 @@ components:
           properties:
             key:
               description: ''
-              type: number
+              type: integer
             value:
               description: ''
-              type: number
+              type: integer
     OutputFormat:
       type: object
       properties:
@@ -539,13 +539,13 @@ components:
           type: array
         totalOutputSize:
           description: Total size of the distributed data in bytes
-          type: number
+          type: integer
         totalDistributionRecords:
           description: >-
             The number of distribution records in the file initially passed to
             this endpoint's corresponding POST route. Each record corresponds to
             an end user targeted by the distribution request
-          type: number
+          type: integer
       required:
         - fileDetails
         - totalOutputSize
@@ -558,7 +558,7 @@ components:
           type: string
         lineCount:
           description: ''
-          type: number
+          type: integer
       required:
         - fileName
         - lineCount
@@ -567,7 +567,7 @@ components:
       type: object
       properties:
         httpStatusCode:
-          type: number
+          type: integer
           description: The integer HTTP error status code for this problem
         errorCode:
           type: string
@@ -575,4 +575,3 @@ components:
         message:
           type: string
           description: Human readable error message
-

--- a/models/distribution/swagger.expected
+++ b/models/distribution/swagger.expected
@@ -48,7 +48,7 @@ paths:
                 properties:
                   id:
                     description: ''
-                    type: number
+                    type: integer
     get:
       tags:
         - Destination
@@ -59,7 +59,7 @@ paths:
           name: offset
           description: Offset of the record (starting from 0) to include in the response.
           schema:
-            type: number
+            type: integer
             default: 0
         - in: query
           name: limit
@@ -67,7 +67,7 @@ paths:
             Number of records to return. If unspecified, 10 records will be
             returned. Maximum value for limit can be 100
           schema:
-            type: number
+            type: integer
             default: 10
             maximum: 100
         - in: query
@@ -83,7 +83,7 @@ paths:
             X-Total-Count:
               description: Total number of records in the data set.
               schema:
-                type: number
+                type: integer
           content:
             application/json:
               schema:
@@ -107,7 +107,7 @@ paths:
           required: true
           description: ''
           schema:
-            type: number
+            type: integer
   '/v1/destinations/{parentId}/taxonomy-configurations':
     post:
       tags:
@@ -129,14 +129,14 @@ paths:
                 properties:
                   id:
                     description: ''
-                    type: number
+                    type: integer
       parameters:
         - in: path
           name: parentId
           description: Id of parent Destination
           required: true
           schema:
-            type: number
+            type: integer
     get:
       tags:
         - Destination / TaxonomyConfiguration
@@ -147,7 +147,7 @@ paths:
           name: offset
           description: Offset of the record (starting from 0) to include in the response.
           schema:
-            type: number
+            type: integer
             default: 0
         - in: query
           name: limit
@@ -155,7 +155,7 @@ paths:
             Number of records to return. If unspecified, 10 records will be
             returned. Maximum value for limit can be 100
           schema:
-            type: number
+            type: integer
             default: 10
             maximum: 100
         - in: query
@@ -163,13 +163,13 @@ paths:
           description: ''
           required: false
           schema:
-            type: number
+            type: integer
         - in: path
           name: parentId
           description: Id of parent Destination
           required: true
           schema:
-            type: number
+            type: integer
       responses:
         '200':
           description: TaxonomyConfigurations retrieved successfully
@@ -177,7 +177,7 @@ paths:
             X-Total-Count:
               description: Total number of records in the data set.
               schema:
-                type: number
+                type: integer
           content:
             application/json:
               schema:
@@ -202,13 +202,13 @@ paths:
           required: true
           description: ''
           schema:
-            type: number
+            type: integer
         - in: path
           name: parentId
           description: Id of parent Destination
           required: true
           schema:
-            type: number
+            type: integer
     put:
       tags:
         - Destination / TaxonomyConfiguration
@@ -223,13 +223,13 @@ paths:
           required: true
           description: ''
           schema:
-            type: number
+            type: integer
         - in: path
           name: parentId
           description: Id of parent Destination
           required: true
           schema:
-            type: number
+            type: integer
   '/v1/destinations/{parentId}/integrations':
     post:
       tags:
@@ -251,14 +251,14 @@ paths:
                 properties:
                   id:
                     description: ''
-                    type: number
+                    type: integer
       parameters:
         - in: path
           name: parentId
           description: Id of parent Destination
           required: true
           schema:
-            type: number
+            type: integer
     get:
       tags:
         - Destination / Integration
@@ -269,7 +269,7 @@ paths:
           name: offset
           description: Offset of the record (starting from 0) to include in the response.
           schema:
-            type: number
+            type: integer
             default: 0
         - in: query
           name: limit
@@ -277,7 +277,7 @@ paths:
             Number of records to return. If unspecified, 10 records will be
             returned. Maximum value for limit can be 100
           schema:
-            type: number
+            type: integer
             default: 10
             maximum: 100
         - in: query
@@ -291,7 +291,7 @@ paths:
           description: Id of parent Destination
           required: true
           schema:
-            type: number
+            type: integer
       responses:
         '200':
           description: Integrations retrieved successfully
@@ -299,7 +299,7 @@ paths:
             X-Total-Count:
               description: Total number of records in the data set.
               schema:
-                type: number
+                type: integer
           content:
             application/json:
               schema:
@@ -323,13 +323,13 @@ paths:
           required: true
           description: ''
           schema:
-            type: number
+            type: integer
         - in: path
           name: parentId
           description: Id of parent Destination
           required: true
           schema:
-            type: number
+            type: integer
     put:
       tags:
         - Destination / Integration
@@ -344,13 +344,13 @@ paths:
           required: true
           description: ''
           schema:
-            type: number
+            type: integer
         - in: path
           name: parentId
           description: Id of parent Destination
           required: true
           schema:
-            type: number
+            type: integer
   '/v1/destinations/{parentId}/endpoints':
     post:
       tags:
@@ -372,14 +372,14 @@ paths:
                 properties:
                   id:
                     description: ''
-                    type: number
+                    type: integer
       parameters:
         - in: path
           name: parentId
           description: Id of parent Destination
           required: true
           schema:
-            type: number
+            type: integer
     get:
       tags:
         - Destination / Endpoint
@@ -390,7 +390,7 @@ paths:
           name: offset
           description: Offset of the record (starting from 0) to include in the response.
           schema:
-            type: number
+            type: integer
             default: 0
         - in: query
           name: limit
@@ -398,7 +398,7 @@ paths:
             Number of records to return. If unspecified, 10 records will be
             returned. Maximum value for limit can be 100
           schema:
-            type: number
+            type: integer
             default: 10
             maximum: 100
         - in: query
@@ -412,7 +412,7 @@ paths:
           description: Id of parent Destination
           required: true
           schema:
-            type: number
+            type: integer
       responses:
         '200':
           description: Endpoints retrieved successfully
@@ -420,7 +420,7 @@ paths:
             X-Total-Count:
               description: Total number of records in the data set.
               schema:
-                type: number
+                type: integer
           content:
             application/json:
               schema:
@@ -444,13 +444,13 @@ paths:
           required: true
           description: ''
           schema:
-            type: number
+            type: integer
         - in: path
           name: parentId
           description: Id of parent Destination
           required: true
           schema:
-            type: number
+            type: integer
     put:
       tags:
         - Destination / Endpoint
@@ -465,13 +465,13 @@ paths:
           required: true
           description: ''
           schema:
-            type: number
+            type: integer
         - in: path
           name: parentId
           description: Id of parent Destination
           required: true
           schema:
-            type: number
+            type: integer
   '/v1/destinations/{parentId}/packagers':
     post:
       tags:
@@ -493,14 +493,14 @@ paths:
                 properties:
                   id:
                     description: ''
-                    type: number
+                    type: integer
       parameters:
         - in: path
           name: parentId
           description: Id of parent Destination
           required: true
           schema:
-            type: number
+            type: integer
     get:
       tags:
         - Destination / Packager
@@ -511,7 +511,7 @@ paths:
           name: offset
           description: Offset of the record (starting from 0) to include in the response.
           schema:
-            type: number
+            type: integer
             default: 0
         - in: query
           name: limit
@@ -519,7 +519,7 @@ paths:
             Number of records to return. If unspecified, 10 records will be
             returned. Maximum value for limit can be 100
           schema:
-            type: number
+            type: integer
             default: 10
             maximum: 100
         - in: path
@@ -527,7 +527,7 @@ paths:
           description: Id of parent Destination
           required: true
           schema:
-            type: number
+            type: integer
       responses:
         '200':
           description: Packagers retrieved successfully
@@ -535,7 +535,7 @@ paths:
             X-Total-Count:
               description: Total number of records in the data set.
               schema:
-                type: number
+                type: integer
           content:
             application/json:
               schema:
@@ -559,13 +559,13 @@ paths:
           required: true
           description: ''
           schema:
-            type: number
+            type: integer
         - in: path
           name: parentId
           description: Id of parent Destination
           required: true
           schema:
-            type: number
+            type: integer
   '/v1/destinations/{parentId}/formatters':
     post:
       tags:
@@ -587,14 +587,14 @@ paths:
                 properties:
                   id:
                     description: ''
-                    type: number
+                    type: integer
       parameters:
         - in: path
           name: parentId
           description: Id of parent Destination
           required: true
           schema:
-            type: number
+            type: integer
     get:
       tags:
         - Destination / Formatter
@@ -605,7 +605,7 @@ paths:
           name: offset
           description: Offset of the record (starting from 0) to include in the response.
           schema:
-            type: number
+            type: integer
             default: 0
         - in: query
           name: limit
@@ -613,7 +613,7 @@ paths:
             Number of records to return. If unspecified, 10 records will be
             returned. Maximum value for limit can be 100
           schema:
-            type: number
+            type: integer
             default: 10
             maximum: 100
         - in: path
@@ -621,7 +621,7 @@ paths:
           description: Id of parent Destination
           required: true
           schema:
-            type: number
+            type: integer
       responses:
         '200':
           description: Formatters retrieved successfully
@@ -629,7 +629,7 @@ paths:
             X-Total-Count:
               description: Total number of records in the data set.
               schema:
-                type: number
+                type: integer
           content:
             application/json:
               schema:
@@ -653,13 +653,13 @@ paths:
           required: true
           description: ''
           schema:
-            type: number
+            type: integer
         - in: path
           name: parentId
           description: Id of parent Destination
           required: true
           schema:
-            type: number
+            type: integer
   '/v1/destinations/{parentId}/deliverers':
     post:
       tags:
@@ -681,14 +681,14 @@ paths:
                 properties:
                   id:
                     description: ''
-                    type: number
+                    type: integer
       parameters:
         - in: path
           name: parentId
           description: Id of parent Destination
           required: true
           schema:
-            type: number
+            type: integer
     get:
       tags:
         - Destination / Deliverer
@@ -699,7 +699,7 @@ paths:
           name: offset
           description: Offset of the record (starting from 0) to include in the response.
           schema:
-            type: number
+            type: integer
             default: 0
         - in: query
           name: limit
@@ -707,7 +707,7 @@ paths:
             Number of records to return. If unspecified, 10 records will be
             returned. Maximum value for limit can be 100
           schema:
-            type: number
+            type: integer
             default: 10
             maximum: 100
         - in: path
@@ -715,7 +715,7 @@ paths:
           description: Id of parent Destination
           required: true
           schema:
-            type: number
+            type: integer
       responses:
         '200':
           description: Deliverers retrieved successfully
@@ -723,7 +723,7 @@ paths:
             X-Total-Count:
               description: Total number of records in the data set.
               schema:
-                type: number
+                type: integer
           content:
             application/json:
               schema:
@@ -747,13 +747,13 @@ paths:
           required: true
           description: ''
           schema:
-            type: number
+            type: integer
         - in: path
           name: parentId
           description: Id of parent Destination
           required: true
           schema:
-            type: number
+            type: integer
 components:
   parameters: {}
   schemas:
@@ -770,7 +770,7 @@ components:
       properties:
         id:
           description: ''
-          type: number
+          type: integer
         name:
           description: ''
           type: string
@@ -802,7 +802,7 @@ components:
       properties:
         id:
           description: ''
-          type: number
+          type: integer
         name:
           description: ''
           type: string
@@ -834,7 +834,7 @@ components:
           type: array
         taxonomyConfigurationId:
           description: ''
-          type: number
+          type: integer
           example: Link to a Destination--TaxonomyConfiguration  resource via its id
       required:
         - name
@@ -845,7 +845,7 @@ components:
       properties:
         id:
           description: ''
-          type: number
+          type: integer
         name:
           description: ''
           type: string
@@ -856,7 +856,7 @@ components:
           type: array
         taxonomyConfigurationId:
           description: ''
-          type: number
+          type: integer
           example: Link to a Destination--TaxonomyConfiguration  resource via its id
       required:
         - id
@@ -882,7 +882,7 @@ components:
             its id
         endpointId:
           description: ''
-          type: number
+          type: integer
           example: Link to a Destination--Endpoint  resource via its id
       required:
         - identifierPoolId
@@ -898,15 +898,15 @@ components:
           type: string
         packagerId:
           description: ''
-          type: number
+          type: integer
           example: Link to a Destination--Packager  resource via its id
         formatterId:
           description: ''
-          type: number
+          type: integer
           example: Link to a Destination--Formatter  resource via its id
         delivererId:
           description: ''
-          type: number
+          type: integer
           example: Link to a Destination--Deliverer  resource via its id
         endpointProperties:
           description: ''
@@ -925,7 +925,7 @@ components:
       properties:
         id:
           description: ''
-          type: number
+          type: integer
         name:
           description: ''
           type: string
@@ -934,15 +934,15 @@ components:
           type: string
         packagerId:
           description: ''
-          type: number
+          type: integer
           example: Link to a Destination--Packager  resource via its id
         formatterId:
           description: ''
-          type: number
+          type: integer
           example: Link to a Destination--Formatter  resource via its id
         delivererId:
           description: ''
-          type: number
+          type: integer
           example: Link to a Destination--Deliverer  resource via its id
         endpointProperties:
           description: ''
@@ -1003,7 +1003,7 @@ components:
       properties:
         id:
           description: ''
-          type: number
+          type: integer
         macro:
           description: ''
           type: string
@@ -1036,7 +1036,7 @@ components:
       properties:
         id:
           description: ''
-          type: number
+          type: integer
         macro:
           description: ''
           type: string
@@ -1091,7 +1091,7 @@ components:
       properties:
         id:
           description: ''
-          type: number
+          type: integer
         protocol:
           description: ''
           type: string
@@ -1116,7 +1116,7 @@ components:
       type: object
       properties:
         httpStatusCode:
-          type: number
+          type: integer
           description: The integer HTTP error status code for this problem
         errorCode:
           type: string
@@ -1124,4 +1124,3 @@ components:
         message:
           type: string
           description: Human readable error message
-

--- a/models/file/swagger.expected
+++ b/models/file/swagger.expected
@@ -49,7 +49,7 @@ paths:
           name: offset
           description: Offset of the record (starting from 0) to include in the response.
           schema:
-            type: number
+            type: integer
             default: 0
         - in: query
           name: limit
@@ -57,7 +57,7 @@ paths:
             Number of records to return. If unspecified, 10 records will be
             returned. Maximum value for limit can be 100
           schema:
-            type: number
+            type: integer
             default: 10
             maximum: 100
         - in: query
@@ -79,7 +79,7 @@ paths:
             X-Total-Count:
               description: Total number of records in the data set.
               schema:
-                type: number
+                type: integer
           content:
             application/json:
               schema:
@@ -136,7 +136,7 @@ paths:
           name: offset
           description: Offset of the record (starting from 0) to include in the response.
           schema:
-            type: number
+            type: integer
             default: 0
         - in: query
           name: limit
@@ -144,7 +144,7 @@ paths:
             Number of records to return. If unspecified, 10 records will be
             returned. Maximum value for limit can be 100
           schema:
-            type: number
+            type: integer
             default: 10
             maximum: 100
         - in: query
@@ -160,7 +160,7 @@ paths:
             X-Total-Count:
               description: Total number of records in the data set.
               schema:
-                type: number
+                type: integer
           content:
             application/json:
               schema:
@@ -224,7 +224,7 @@ paths:
                 properties:
                   id:
                     description: ''
-                    type: number
+                    type: integer
       parameters:
         - in: path
           name: parentId
@@ -242,7 +242,7 @@ paths:
           name: offset
           description: Offset of the record (starting from 0) to include in the response.
           schema:
-            type: number
+            type: integer
             default: 0
         - in: query
           name: limit
@@ -250,7 +250,7 @@ paths:
             Number of records to return. If unspecified, 10 records will be
             returned. Maximum value for limit can be 100
           schema:
-            type: number
+            type: integer
             default: 10
             maximum: 100
         - in: query
@@ -272,7 +272,7 @@ paths:
             X-Total-Count:
               description: Total number of records in the data set.
               schema:
-                type: number
+                type: integer
           content:
             application/json:
               schema:
@@ -296,7 +296,7 @@ paths:
           required: true
           description: ''
           schema:
-            type: number
+            type: integer
         - in: path
           name: parentId
           description: Id of parent Directory
@@ -324,7 +324,7 @@ paths:
                 properties:
                   id:
                     description: ''
-                    type: number
+                    type: integer
     get:
       tags:
         - DirectoryDeleteRequest
@@ -335,7 +335,7 @@ paths:
           name: offset
           description: Offset of the record (starting from 0) to include in the response.
           schema:
-            type: number
+            type: integer
             default: 0
         - in: query
           name: limit
@@ -343,7 +343,7 @@ paths:
             Number of records to return. If unspecified, 10 records will be
             returned. Maximum value for limit can be 100
           schema:
-            type: number
+            type: integer
             default: 10
             maximum: 100
         - in: query
@@ -351,7 +351,7 @@ paths:
           description: ''
           required: false
           schema:
-            type: number
+            type: integer
       responses:
         '200':
           description: DirectoryDeleteRequests retrieved successfully
@@ -359,7 +359,7 @@ paths:
             X-Total-Count:
               description: Total number of records in the data set.
               schema:
-                type: number
+                type: integer
           content:
             application/json:
               schema:
@@ -383,7 +383,7 @@ paths:
           required: true
           description: ''
           schema:
-            type: number
+            type: integer
   '/v1/directory-delete-requests/{parentId}/cancels':
     post:
       tags:
@@ -400,14 +400,14 @@ paths:
                 properties:
                   id:
                     description: ''
-                    type: number
+                    type: integer
       parameters:
         - in: path
           name: parentId
           description: Id of parent DirectoryDeleteRequest
           required: true
           schema:
-            type: number
+            type: integer
 components:
   parameters: {}
   schemas:
@@ -511,7 +511,7 @@ components:
       properties:
         id:
           description: ''
-          type: number
+          type: integer
         name:
           description: ''
           type: string
@@ -549,7 +549,7 @@ components:
       properties:
         id:
           description: ''
-          type: number
+          type: integer
         directoryId:
           description: ''
           type: string
@@ -584,7 +584,7 @@ components:
       type: object
       properties:
         httpStatusCode:
-          type: number
+          type: integer
           description: The integer HTTP error status code for this problem
         errorCode:
           type: string
@@ -592,4 +592,3 @@ components:
         message:
           type: string
           description: Human readable error message
-

--- a/models/request/swagger.expected
+++ b/models/request/swagger.expected
@@ -38,7 +38,7 @@ paths:
                 properties:
                   id:
                     description: ''
-                    type: number
+                    type: integer
     get:
       tags:
         - UploadRequest
@@ -49,7 +49,7 @@ paths:
           name: offset
           description: Offset of the record (starting from 0) to include in the response.
           schema:
-            type: number
+            type: integer
             default: 0
         - in: query
           name: limit
@@ -57,7 +57,7 @@ paths:
             Number of records to return. If unspecified, 10 records will be
             returned. Maximum value for limit can be 100
           schema:
-            type: number
+            type: integer
             default: 10
             maximum: 100
         - in: query
@@ -73,7 +73,7 @@ paths:
             X-Total-Count:
               description: Total number of records in the data set.
               schema:
-                type: number
+                type: integer
           content:
             application/json:
               schema:
@@ -97,7 +97,7 @@ paths:
           required: true
           description: ''
           schema:
-            type: number
+            type: integer
   '/v1/upload-requests/{parentId}/status':
     get:
       tags:
@@ -117,7 +117,7 @@ paths:
           description: Id of parent UploadRequest
           required: true
           schema:
-            type: number
+            type: integer
   '/v1/upload-requests/{parentId}/record-sets':
     post:
       tags:
@@ -139,14 +139,14 @@ paths:
                 properties:
                   id:
                     description: ''
-                    type: number
+                    type: integer
       parameters:
         - in: path
           name: parentId
           description: Id of parent UploadRequest
           required: true
           schema:
-            type: number
+            type: integer
   '/v1/upload-requests/{parentId}/record-sets/{id}':
     get:
       tags:
@@ -166,13 +166,13 @@ paths:
           required: true
           description: ''
           schema:
-            type: number
+            type: integer
         - in: path
           name: parentId
           description: Id of parent UploadRequest
           required: true
           schema:
-            type: number
+            type: integer
   '/v1/upload-requests/{parentId}/start-processing-actions':
     post:
       tags:
@@ -210,7 +210,7 @@ paths:
           description: Id of parent UploadRequest
           required: true
           schema:
-            type: number
+            type: integer
   '/v1/upload-requests/{parentId}/stop-processing-actions':
     post:
       tags:
@@ -232,14 +232,14 @@ paths:
                 properties:
                   id:
                     description: ''
-                    type: number
+                    type: integer
       parameters:
         - in: path
           name: parentId
           description: Id of parent UploadRequest
           required: true
           schema:
-            type: number
+            type: integer
   '/v1/upload-requests/{parentId}/stop-processing-actions/{id}':
     get:
       tags:
@@ -259,13 +259,13 @@ paths:
           required: true
           description: ''
           schema:
-            type: number
+            type: integer
         - in: path
           name: parentId
           description: Id of parent UploadRequest
           required: true
           schema:
-            type: number
+            type: integer
 components:
   parameters: {}
   schemas:
@@ -294,7 +294,7 @@ components:
       properties:
         id:
           description: ''
-          type: number
+          type: integer
         name:
           description: ''
           type: string
@@ -323,10 +323,10 @@ components:
       properties:
         id:
           description: ''
-          type: number
+          type: integer
         recordsProcessed:
           description: ''
-          type: number
+          type: integer
         completed:
           description: ''
           type: boolean
@@ -353,7 +353,7 @@ components:
       properties:
         id:
           description: ''
-          type: number
+          type: integer
         company:
           description: ''
           type: string
@@ -393,7 +393,7 @@ components:
       properties:
         id:
           description: ''
-          type: number
+          type: integer
         when:
           description: ''
           type: string
@@ -407,7 +407,7 @@ components:
       type: object
       properties:
         httpStatusCode:
-          type: number
+          type: integer
           description: The integer HTTP error status code for this problem
         errorCode:
           type: string
@@ -415,4 +415,3 @@ components:
         message:
           type: string
           description: Human readable error message
-

--- a/models/simple-resource/swagger.expected
+++ b/models/simple-resource/swagger.expected
@@ -41,7 +41,7 @@ paths:
           name: offset
           description: Offset of the record (starting from 0) to include in the response.
           schema:
-            type: number
+            type: integer
             default: 0
         - in: query
           name: limit
@@ -49,7 +49,7 @@ paths:
             Number of records to return. If unspecified, 10 records will be
             returned. Maximum value for limit can be 100
           schema:
-            type: number
+            type: integer
             default: 10
             maximum: 100
         - in: query
@@ -71,7 +71,7 @@ paths:
             X-Total-Count:
               description: Total number of records in the data set.
               schema:
-                type: number
+                type: integer
           content:
             application/json:
               schema:
@@ -178,7 +178,7 @@ components:
       type: object
       properties:
         httpStatusCode:
-          type: number
+          type: integer
           description: The integer HTTP error status code for this problem
         errorCode:
           type: string
@@ -186,4 +186,3 @@ components:
         message:
           type: string
           description: Human readable error message
-

--- a/models/singleton/swagger.expected
+++ b/models/singleton/swagger.expected
@@ -36,7 +36,7 @@ paths:
                 properties:
                   id:
                     description: ''
-                    type: number
+                    type: integer
   '/v1/resources/{id}':
     get:
       tags:
@@ -56,7 +56,7 @@ paths:
           required: true
           description: ''
           schema:
-            type: number
+            type: integer
   '/v1/resources/{parentId}/metadata':
     get:
       tags:
@@ -76,7 +76,7 @@ paths:
           description: Id of parent Resource
           required: true
           schema:
-            type: number
+            type: integer
     put:
       tags:
         - Resource / Metadata
@@ -91,7 +91,7 @@ paths:
           description: Id of parent Resource
           required: true
           schema:
-            type: number
+            type: integer
   /v1/singleton-resource:
     get:
       tags:
@@ -150,7 +150,7 @@ components:
       properties:
         id:
           description: ''
-          type: number
+          type: integer
         name:
           description: ''
           type: string
@@ -186,7 +186,7 @@ components:
       type: object
       properties:
         httpStatusCode:
-          type: number
+          type: integer
           description: The integer HTTP error status code for this problem
         errorCode:
           type: string

--- a/models/stringmaps/swagger.expected
+++ b/models/stringmaps/swagger.expected
@@ -30,7 +30,7 @@ paths:
                 properties:
                   id:
                     description: ''
-                    type: number
+                    type: integer
   '/v1/s-maps/{id}':
     put:
       tags:
@@ -51,7 +51,7 @@ paths:
           required: true
           description: ''
           schema:
-            type: number
+            type: integer
 components:
   parameters: {}
   schemas:
@@ -62,7 +62,7 @@ components:
           description: ''
           type: object
           additionalProperties:
-            type: number
+            type: integer
         test:
           description: ''
           type: string
@@ -71,7 +71,7 @@ components:
           $ref: '#/components/schemas/InputKey'
         a:
           description: ''
-          type: number
+          type: integer
         b:
           description: ''
           type: string
@@ -130,7 +130,7 @@ components:
           properties:
             num:
               description: ''
-              type: number
+              type: integer
     Mystruct:
       allOf:
         - $ref: '#/components/schemas/InputKey'
@@ -155,7 +155,7 @@ components:
       type: object
       properties:
         httpStatusCode:
-          type: number
+          type: integer
           description: The integer HTTP error status code for this problem
         errorCode:
           type: string
@@ -163,4 +163,3 @@ components:
         message:
           type: string
           description: Human readable error message
-

--- a/models/upversion/swagger.expected
+++ b/models/upversion/swagger.expected
@@ -34,7 +34,7 @@ paths:
           required: true
           description: ''
           schema:
-            type: number
+            type: integer
   /v1/resource-bs:
     post:
       tags:
@@ -56,7 +56,7 @@ paths:
                 properties:
                   id:
                     description: ''
-                    type: number
+                    type: integer
   '/v1/resource-bs/{id}':
     get:
       tags:
@@ -76,7 +76,7 @@ paths:
           required: true
           description: ''
           schema:
-            type: number
+            type: integer
     put:
       tags:
         - ResourceB
@@ -91,7 +91,7 @@ paths:
           required: true
           description: ''
           schema:
-            type: number
+            type: integer
   /v2/resource-bs:
     post:
       tags:
@@ -113,7 +113,7 @@ paths:
                 properties:
                   id:
                     description: ''
-                    type: number
+                    type: integer
   '/v2/resource-bs/{id}':
     get:
       tags:
@@ -133,7 +133,7 @@ paths:
           required: true
           description: ''
           schema:
-            type: number
+            type: integer
   '/v2/resource-bs/{parentId}/subs':
     post:
       tags:
@@ -155,14 +155,14 @@ paths:
                 properties:
                   id:
                     description: ''
-                    type: number
+                    type: integer
       parameters:
         - in: path
           name: parentId
           description: Id of parent v2-ResourceB
           required: true
           schema:
-            type: number
+            type: integer
   '/v2/resource-bs/{parentId}/subs/{id}':
     get:
       tags:
@@ -182,13 +182,13 @@ paths:
           required: true
           description: ''
           schema:
-            type: number
+            type: integer
         - in: path
           name: parentId
           description: Id of parent v2-ResourceB
           required: true
           schema:
-            type: number
+            type: integer
 components:
   parameters: {}
   schemas:
@@ -197,17 +197,17 @@ components:
       properties:
         id:
           description: ''
-          type: number
+          type: integer
         name:
           description: ''
           type: string
         bId:
           description: ''
-          type: number
+          type: integer
           example: Link to a ResourceB  resource via its id
         newBId:
           description: ''
-          type: number
+          type: integer
           example: Link to a v2-ResourceB  resource via its id
       required:
         - id
@@ -219,7 +219,7 @@ components:
       properties:
         size:
           description: ''
-          type: number
+          type: integer
       required:
         - size
     ResourceBOutput:
@@ -227,10 +227,10 @@ components:
       properties:
         id:
           description: ''
-          type: number
+          type: integer
         size:
           description: ''
-          type: number
+          type: integer
       required:
         - id
         - size
@@ -239,7 +239,7 @@ components:
       properties:
         totalSize:
           description: ''
-          type: number
+          type: integer
       required:
         - totalSize
     v2-ResourceBOutput:
@@ -247,10 +247,10 @@ components:
       properties:
         id:
           description: ''
-          type: number
+          type: integer
         totalSize:
           description: ''
-          type: number
+          type: integer
       required:
         - id
         - totalSize
@@ -267,7 +267,7 @@ components:
       properties:
         id:
           description: ''
-          type: number
+          type: integer
         name:
           description: ''
           type: string
@@ -279,7 +279,7 @@ components:
       type: object
       properties:
         httpStatusCode:
-          type: number
+          type: integer
           description: The integer HTTP error status code for this problem
         errorCode:
           type: string
@@ -287,4 +287,3 @@ components:
         message:
           type: string
           description: Human readable error message
-

--- a/src/genswagger.ts
+++ b/src/genswagger.ts
@@ -294,7 +294,7 @@ export default class SwagGen extends BaseGen {
                 description:
                     "Offset of the record (starting from 0) to include in the response.",
                 schema: {
-                    type: "number",
+                    type: "integer",
                     default: 0
                 }
             })
@@ -304,7 +304,7 @@ export default class SwagGen extends BaseGen {
                 description: `Number of records to return. If unspecified, 10 records will be returned.\
  Maximum value for limit can be 100`,
                 schema: {
-                    type: "number",
+                    type: "integer",
                     default: 10,
                     maximum: 100
                 }
@@ -331,7 +331,7 @@ export default class SwagGen extends BaseGen {
                         "X-Total-Count": {
                             description:
                                 "Total number of records in the data set.",
-                            schema: { type: "number" }
+                            schema: { type: "integer" }
                         }
                     },
                     content: {
@@ -555,7 +555,7 @@ export default class SwagGen extends BaseGen {
                 }
                 break
             case "int":
-                schema.type = "number"
+                schema.type = "integer"
                 break
             case "boolean":
                 schema.type = "boolean"
@@ -942,7 +942,7 @@ export default class SwagGen extends BaseGen {
             type: "object",
             properties: {
                 httpStatusCode: {
-                    type: "number",
+                    type: "integer",
                     description:
                         "The integer HTTP error status code for this problem"
                 },


### PR DESCRIPTION
## Context
Got some funny situations where auto-generated examples would generate these long decimals for things that should definitely be integers. Depending on how you generate your documentation and auto-generated examples, you get something like this for the response for a POST:
![image](https://user-images.githubusercontent.com/12236876/66544060-a2fb9180-eb69-11e9-8a85-93230bd432dd.png)
Or for some of our stats use cases, you can specify the maximum members in a segment (`"cap"`), which is always going to be an integer, but we got
![image](https://user-images.githubusercontent.com/12236876/66544142-d5a58a00-eb69-11e9-8f08-78d7d6040a25.png)

I realized it's because of this in `genswagger.ts`:
```ts
            case "int":
                schema.type = "number" // should be "integer"
                break
```
## Changes
The only important changes are in `src/genswagger.ts`. Specifically, I changed so that the following are `type: integer` instead of `type: number`:
* Any uses of the reslang primitive `int`
* MULTIGET request pagination offset
* MULTIGET request limit
* MULTIGET response header `X-Total-Count`
* `httpStatusCode` property in the `Error` definition

The other changes are just updating `swagger.expected`s for tests. I'm not sure what you want to do about `models/direct2dist/distribution.yaml` and `concepts/distribution-swagger.yaml`, or the actual open API spec that dist has in their repo, for that matter. 