### PR TITLE
Always use the master image tag in reslang-docker script

### DIFF
--- a/reslang-docker.sh
+++ b/reslang-docker.sh
@@ -11,4 +11,4 @@ DIR_NAME=$(basename "$FULL_PATH")
 SRC_PATH="/app/reslang/${DIR_NAME}"
 echo ${SRC_PATH}
 
-docker run -v "${FULL_PATH}:${SRC_PATH}" gcr.io/liveramp-eng/reslang:91c9039 ${SRC_PATH} --stdout
+docker run -v "${FULL_PATH}:${SRC_PATH}" gcr.io/liveramp-eng/reslang:master ${SRC_PATH} --stdout


### PR DESCRIPTION
[Here](https://console.cloud.google.com/gcr/images/liveramp-eng/GLOBAL/reslang) is our image registry. I think it makes sense for us to always use the master image tag. The current one is out of date.

Alternatively, we could make the image tag a parameter to the script, probably defaulting to `master` if unspecified by the user.