### PR TITLE
Direct informational logs from docker script to STDERR

### DIFF
--- a/reslang-docker.sh
+++ b/reslang-docker.sh
@@ -2,13 +2,13 @@
 
 set -eu
 
-echo "This only accepts absolute paths e.g. /User/a/b/models/"
+echo "This only accepts absolute paths e.g. /User/a/b/models/" >&2
 
 FULL_PATH=$1
-echo "Reslang files to read: $FULL_PATH"
+echo "Reslang files to read: $FULL_PATH" >&2
 
 DIR_NAME=$(basename "$FULL_PATH")
 SRC_PATH="/app/reslang/${DIR_NAME}"
-echo ${SRC_PATH}
+echo ${SRC_PATH} >&2
 
 docker run -v "${FULL_PATH}:${SRC_PATH}" gcr.io/liveramp-eng/reslang:master ${SRC_PATH} --stdout


### PR DESCRIPTION
Since the docker script writes the swagger yaml to STDOUT (and since the docker container can't access the system clipboard), I want to be able to use it like:

```bash reslang-docker.sh ~/code/api-specs/auto-import-api/ > ~/code/api-specs/auto-import-api/auto-import.yaml```

But that currently echoes the opening log lines of the wrapper script into my yaml. This change redirects those messages to STDERR and leaves STDOUT clean (this seems appropriate as they are "diagnostic messages").