### PR TITLE
Allow MULTIGET for singletons and bulk for subresources

### DIFF
--- a/src/genbase.ts
+++ b/src/genbase.ts
@@ -347,7 +347,7 @@ Actions cannot have subresources`
     }
 
     protected formOperationId(def: IResourceLike, verb: Verbs) {
-        const bulk = def.bulk ? "Bulk " : ""
+        const bulk = def.type == "action" && def.bulk ? "Bulk " : ""
 
         // handle action creation separately - make it sound like an action e.g. retry DeliveryRequest
         if (def.type === "action" && verb === Verbs.POST) {
@@ -370,13 +370,9 @@ Actions cannot have subresources`
             case Verbs.GET:
                 return "Get " + bulk + def.name
             case Verbs.MULTIGET:
-                const plural = pluralizeName(def.name)
-                return (
-                    "Get " +
-                    (plural === def.name ? "multiple " : "") +
-                    bulk +
-                    plural
-                )
+                const plural = def.singleton ? def.name : pluralizeName(def.name)
+                const multiple = (plural === def.name && !def.singleton) ? "multiple " : ""
+                return "Get " + multiple + bulk + plural
             case Verbs.DELETE:
                 return "Delete " + bulk + def.name
         }

--- a/src/genswagger.ts
+++ b/src/genswagger.ts
@@ -97,7 +97,7 @@ export default class SwagGen extends BaseGen {
                         full = pluralizeName(full)
                     }
                     pname = actual.parentName
-                    if (action && el.bulk && first) {
+                    if (el.bulk && first) {
                         parents = `/${full}` + parents
                     } else {
                         if (!actual.singleton) {
@@ -133,13 +133,13 @@ export default class SwagGen extends BaseGen {
                 const post = this.extractOp(el, "POST")
                 const multiget = this.extractOp(el, "MULTIGET")
 
-                if (singleton && (post || multiget)) {
+                if (singleton && post) {
                     throw new Error(
-                        `${el.short} is a singleton - cannot have POST or MULTIGET`
+                        `${el.short} is a singleton - cannot have POST`
                     )
                 }
 
-                if (!singleton && (post || multiget)) {
+                if (post || multiget) {
                     paths[`/${major}${parents}/${actionPath}${name}`] = path
                     this.formNonIdOperations(
                         el,
@@ -194,7 +194,7 @@ export default class SwagGen extends BaseGen {
         post: IOperation | null,
         multiget: IOperation | null
     ) {
-        const plural = pluralizeName(el.short)
+        const plural = el.singleton ? el.short : pluralizeName(el.short)
         const unique = this.formSingleUniqueName(el)
         const camel = camelCase(unique)
         const notFound =
@@ -377,7 +377,7 @@ export default class SwagGen extends BaseGen {
                     content: {
                         "application/json": {
                             schema: {
-                                $ref: `#/components/schemas/${camel}MultiResponse`,
+                                $ref: `#/components/schemas/${camel}${el.singleton ? "Output" : "MultiResponse"}`,
                             },
                         },
                     },
@@ -802,10 +802,10 @@ export default class SwagGen extends BaseGen {
                     if (post) {
                         el.generateInput = true
                     }
-                    if (multiget) {
-                        el.generateMulti = true
-                        el.generateOutput = true
-                    }
+                }
+                if (multiget) {
+                    if (!el.singleton) el.generateMulti = true
+                    el.generateOutput = true
                 }
 
                 const get = this.extractOp(el, "GET")

--- a/src/grammar/rest.pegjs
+++ b/src/grammar/rest.pegjs
@@ -11,14 +11,15 @@ resource = _ comment:description? _ future:"future"? _ singleton:"singleton"? _ 
         parents: [], short: respath.short}
 }
 
-subresource = _ comment:description? _ future:"future"? _ singleton:"singleton"? _ type:("subresource") _ respath:parentrespath _ "{" _
+subresource = _ comment:description? _ future:"future"? _ singleton:"singleton"? _ bulk:("bulk" / "resource-level")? _ type:("subresource") _ respath:parentrespath _ "{" _
     attributes:attributes? _ operations:operations? _
 "}" _ ";"? _ {
     return {
         kind: "resource-like",
         comment: comment, future: !!future, singleton: !!singleton, type: type, 
         attributes: attributes, operations: operations,
-        parents: respath.parents, short: respath.short}
+        parents: respath.parents, short: respath.short,
+        bulk: bulk}
 }
 
 action = _ comment:description? _ future:"future"? _ async:("sync"/"async") _ bulk:("bulk" / "resource-level")? _ "action" _ respath:parentrespath _ "{" _

--- a/src/treetypes.ts
+++ b/src/treetypes.ts
@@ -98,7 +98,7 @@ export interface IResourceLike extends IDefinition {
     singleton?: boolean
     future?: boolean
     async?: boolean
-    bulk?: boolean // only for actions, indicates it's on the entire resource, not a single resource
+    bulk?: boolean // indicates it's on the entire resource, not a single resource
 
     // used to see if we generate definitions or not
     generateOutput: boolean


### PR DESCRIPTION
I know _multi_ get for _singleton_ sounds weird, but hear me out :) 

Here is a use case: 
```
resource Pipeline {
   id: int
   name: string
   foo: bar

   /operations GET POST
}

struct PipelineStatus {
    started: date
    completed: date
    status: string
}

singleton subresource Pipeline::History {
    history: PipelineStatus[] output
    /operations MULTIGET
}
```

This (with the changes in this PR) does exactly what I need: 
1. The url looks correct: `GET /v1/pipelines/${id}/history`
2. The response looks good:
```
{
   "history": [ {
      "started": "2000-01-01",
      "completed": "2000-01-02",
       "status": "crashed_and_burned"
   }]
}
```

The only problem is `MULTIGET` is not allowed for singletons (this is what the PR is changing). 
If `History` was not a singleton, it would need to have an id (does not make sense), which could be addressed fairly easily (not require an id for resources that don't have a GET), but even then:
1. The url looks weird: `GET /v1/pipelines/${id}/histories` (plural???) 
2. Response is even worse:
```
   "histories": [{
       "history": { ... }
    }]
```

So, I thought, making `history` a singleton seems to address all three of the problems nicely: singletons don't have ids, they don't need to be pluralized, and they do not need to be wrapped into arrays. It seems to do exactly what I need here. 

**Another use case** is a `Find` function:
```
    resource-level singleton subresource Pipeline::Find {
       foo: string queryonly
       pipeline: value-of Pipeline[] output
       /operations MULTIGET
   }
```

It is another example of a `subresource` that takes advantage of `MULTIGET`, but it is _also_ `resource-level` (this is another change in this PR to allow this), so that it does not need parent id in the url. 

This also generates exactly the API that makes sense. 

Alternatively, I could model this as a (resource-level) `action`, but that again does not make very much sense and seems like a kludge, because `Find` is not really _acting_ on the resource, so the url `/v1/pipelines/actions/find` does not look right at all. 

  



