### PR TITLE
Make clipboard copy error non-fatal

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -121,6 +121,10 @@ function tryClip(text: string, tag: string, silent: boolean) {
 }
 
 function handle(allFiles: string[], silent: boolean) {
+    // If we are writing to stdout don't intermingle it with info msgs
+    if (args.stdout) 
+      silent = true
+
     try {
         // generate a parse tree?
         if (args.parsed) {


### PR DESCRIPTION
Fixes #79: when running on ubuntu (or docker container) without X, copy to clipboard fails resulting in a fatal error. 
Also fixes #82: when `--stdout` is present, do not attempt to clip. 
Fixing this by making the error non-fatal (warn and continue).