### PR TITLE
Preserve namespace when looking for parent of a subresource

### DIFF
--- a/src/genbase.ts
+++ b/src/genbase.ts
@@ -297,6 +297,12 @@ Actions cannot have subresources`
         if (def) {
             return def
         }
+
+        const parts = definitionName.split(".")
+        if (parts.length == 2 && this.mainNamespace === parts[0]) {
+          return this.extractDefinition(parts[1])
+        }
+
         throw new Error("Cannot find definition for " + definitionName)
     }
 


### PR DESCRIPTION
Fixes #86 

When checking rules, and looking for parents of subresource, we  loose the namespace info: subresource name is `namespace.Foo::Bar`,  but `parentName` is just `Foo`, so it fails to be found because it was loaded as `namespace.Foo`. 

Fixing this by extracting namespace from child's name, and prepending it to parent before ascending up the hierarchy. 

(It might be better to just carry the namespace with the definition rather than doing the string surgery every time, but I decided against it because it widens the impact and the scope, and resource hierarchies aren't deep anyway, so this shouldn't hurt performance too much). 