### PR TITLE
fix for "defaults shouldn't be added to PUT and PATCH endpoints #75"

### DIFF
--- a/models/complex-resource/testdata/parsed.expected
+++ b/models/complex-resource/testdata/parsed.expected
@@ -234,7 +234,7 @@
           "full": false,
           "modifiers": {
             "mutable": false,
-            "optional": false,
+            "optional": true,
             "optionalPost": false,
             "optionalPut": false,
             "optionalGet": false,

--- a/models/complex-resource/testdata/swagger.expected
+++ b/models/complex-resource/testdata/swagger.expected
@@ -311,7 +311,6 @@ components:
         - company
         - home
         - homeArray
-        - timeToManufacture
         - other
       description: This is a manufacturer
     CarInput:

--- a/models/patchable/resources.reslang
+++ b/models/patchable/resources.reslang
@@ -1,10 +1,15 @@
 
 configuration-resource Person {
     id: int
-    name: string mutable
-    address: string mutable optional
+    name: string optional mutable default = "Freddo Frog"
+    address: string mutable optional default = "Malibu"
     birthDate: datetime
+    extra: Extra inline
 
     /operations
         POST PUT PATCH GET
+}
+
+structure Extra {
+    notes: string mutable optional default = "no notes!"
 }

--- a/models/patchable/testdata/dotviz.expected
+++ b/models/patchable/testdata/dotviz.expected
@@ -7,4 +7,8 @@ digraph G {
 "Person" [label=<
                     <table border="3" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>Person        </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="left">name: string</td></tr><tr><td align="left">address: string</td></tr><tr><td align="left">birthDate: datetime</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> POST PUT PATCH GET</font></td></tr>"}</table>>];
+"Extra" [label=<
+                    <table border="1" cellborder="0" cellspacing="1"   >
+                    <tr><td><b>Extra        </b></td></tr>        <hr/><tr><td align="left">notes: string</td></tr></table> >];
+"Person" -> "Extra" [dir="back" arrowtail="diamond" label=< <font point-size="8"> extra</font> >];
 }

--- a/models/patchable/testdata/parsed.expected
+++ b/models/patchable/testdata/parsed.expected
@@ -52,7 +52,7 @@
           "full": false,
           "modifiers": {
             "mutable": true,
-            "optional": false,
+            "optional": true,
             "optionalPost": false,
             "optionalPut": false,
             "optionalGet": false,
@@ -61,7 +61,11 @@
             "query": false,
             "representation": false
           },
-          "constraints": {}
+          "constraints": {},
+          "default": {
+            "type": "string",
+            "value": "Freddo Frog"
+          }
         },
         {
           "name": "address",
@@ -87,7 +91,11 @@
             "query": false,
             "representation": false
           },
-          "constraints": {}
+          "constraints": {},
+          "default": {
+            "type": "string",
+            "value": "Malibu"
+          }
         },
         {
           "name": "birthDate",
@@ -100,6 +108,32 @@
             "parentName": ""
           },
           "inline": false,
+          "linked": false,
+          "full": false,
+          "modifiers": {
+            "mutable": false,
+            "optional": false,
+            "optionalPost": false,
+            "optionalPut": false,
+            "optionalGet": false,
+            "output": false,
+            "queryonly": false,
+            "query": false,
+            "representation": false
+          },
+          "constraints": {}
+        },
+        {
+          "name": "extra",
+          "stringMap": false,
+          "type": {
+            "parents": [],
+            "short": "Extra",
+            "name": "Extra",
+            "parentShort": "",
+            "parentName": ""
+          },
+          "inline": true,
           "linked": false,
           "full": false,
           "modifiers": {
@@ -140,6 +174,49 @@
       "parentShort": "",
       "parentName": "",
       "namespace": "",
+      "secondary": false,
+      "file": "resources.reslang"
+    },
+    {
+      "kind": "structure",
+      "type": "structure",
+      "parents": [],
+      "short": "Extra",
+      "attributes": [
+        {
+          "name": "notes",
+          "stringMap": false,
+          "type": {
+            "parents": [],
+            "short": "string",
+            "name": "string",
+            "parentShort": "",
+            "parentName": ""
+          },
+          "inline": false,
+          "linked": false,
+          "full": false,
+          "modifiers": {
+            "mutable": true,
+            "optional": true,
+            "optionalPost": false,
+            "optionalPut": false,
+            "optionalGet": false,
+            "output": false,
+            "queryonly": false,
+            "query": false,
+            "representation": false
+          },
+          "constraints": {},
+          "default": {
+            "type": "string",
+            "value": "no notes!"
+          }
+        }
+      ],
+      "name": "Extra",
+      "parentShort": "",
+      "parentName": "",
       "secondary": false,
       "file": "resources.reslang"
     },

--- a/models/patchable/testdata/swagger.expected
+++ b/models/patchable/testdata/swagger.expected
@@ -116,15 +116,19 @@ components:
       type: object
       properties:
         name:
+          default: Freddo Frog
           type: string
         address:
+          default: Malibu
           type: string
         birthDate:
           type: string
           format: ISO8601 UTC date-time
           example: '2019-04-13T03:35:34Z'
+        notes:
+          default: no notes!
+          type: string
       required:
-        - name
         - birthDate
     PersonOutput:
       type: object
@@ -140,25 +144,31 @@ components:
           type: string
           format: ISO8601 UTC date-time
           example: '2019-04-13T03:35:34Z'
+        notes:
+          type: string
       required:
         - id
-        - name
         - birthDate
     PersonPuttable:
       type: object
       properties:
         name:
+          default: Freddo Frog
           type: string
         address:
+          default: Malibu
           type: string
-      required:
-        - name
+        notes:
+          default: no notes!
+          type: string
     PersonPatchable:
       type: object
       properties:
         name:
           type: string
         address:
+          type: string
+        notes:
           type: string
     StandardError:
       type: object

--- a/models/simple-resource/resources.reslang
+++ b/models/simple-resource/resources.reslang
@@ -22,7 +22,7 @@ structure Manufacturer {
 	company: string example: "This is a company name"
 	home: url example: "This is the company website http://{id}}.liveramp.com"
 	homeArray: url[] example: "Array of urls"
-	timeToManufacture: duration default = "P4D"
+	timeToManufacture: duration optional default = "P4D"
 	other: url
 }
 

--- a/models/simple-resource/testdata/parsed.expected
+++ b/models/simple-resource/testdata/parsed.expected
@@ -234,7 +234,7 @@
           "full": false,
           "modifiers": {
             "mutable": false,
-            "optional": false,
+            "optional": true,
             "optionalPost": false,
             "optionalPut": false,
             "optionalGet": false,

--- a/models/simple-resource/testdata/swagger.expected
+++ b/models/simple-resource/testdata/swagger.expected
@@ -344,7 +344,6 @@ components:
         - company
         - home
         - homeArray
-        - timeToManufacture
         - other
       description: This is a manufacturer
     FooOutput:

--- a/models/stringmaps/resources.reslang
+++ b/models/stringmaps/resources.reslang
@@ -1,9 +1,9 @@
 asset-resource SMap {
     id: int
-    name: string query default="hello"
+    name: string query optional default="hello"
     map: stringmap<int>
     maps: stringmap<Struct2>[] output
-    test: string mutable
+    test: string mutable optional default = "test"
     key: InputKey mutable
     test2: Struct3 inline
 
@@ -27,14 +27,13 @@ union InputKey {
 }
 
 structure Struct3 {
-    a: double
+    a: double optional
         default = 123.9
     b: int output
-        default = 20
-    c: date
+    c: date optional
         default = "12/20/1990"
     e: Struct4 inline
-    f: boolean
+    f: boolean optional
         default = true
 }
 

--- a/models/stringmaps/testdata/parsed.expected
+++ b/models/stringmaps/testdata/parsed.expected
@@ -52,7 +52,7 @@
           "full": false,
           "modifiers": {
             "mutable": false,
-            "optional": false,
+            "optional": true,
             "optionalPost": false,
             "optionalPut": false,
             "optionalGet": false,
@@ -137,7 +137,7 @@
           "full": false,
           "modifiers": {
             "mutable": true,
-            "optional": false,
+            "optional": true,
             "optionalPost": false,
             "optionalPut": false,
             "optionalGet": false,
@@ -146,7 +146,11 @@
             "query": false,
             "representation": false
           },
-          "constraints": {}
+          "constraints": {},
+          "default": {
+            "type": "string",
+            "value": "test"
+          }
         },
         {
           "name": "key",
@@ -444,7 +448,7 @@
           "full": false,
           "modifiers": {
             "mutable": false,
-            "optional": false,
+            "optional": true,
             "optionalPost": false,
             "optionalPut": false,
             "optionalGet": false,
@@ -483,11 +487,7 @@
             "query": false,
             "representation": false
           },
-          "constraints": {},
-          "default": {
-            "type": "numerical",
-            "value": "20"
-          }
+          "constraints": {}
         },
         {
           "name": "c",
@@ -504,7 +504,7 @@
           "full": false,
           "modifiers": {
             "mutable": false,
-            "optional": false,
+            "optional": true,
             "optionalPost": false,
             "optionalPut": false,
             "optionalGet": false,
@@ -560,7 +560,7 @@
           "full": false,
           "modifiers": {
             "mutable": false,
-            "optional": false,
+            "optional": true,
             "optionalPost": false,
             "optionalPut": false,
             "optionalGet": false,

--- a/models/stringmaps/testdata/swagger.expected
+++ b/models/stringmaps/testdata/swagger.expected
@@ -142,6 +142,7 @@ components:
             type: integer
             format: int32
         test:
+          default: test
           type: string
         key:
           allOf:
@@ -162,14 +163,9 @@ components:
           default: true
           type: boolean
       required:
-        - name
         - map
-        - test
         - key
-        - a
-        - c
         - d
-        - f
     SMapOutput:
       type: object
       properties:
@@ -177,7 +173,6 @@ components:
           type: integer
           format: int32
         name:
-          default: hello
           type: string
         map:
           type: object
@@ -201,14 +196,11 @@ components:
             - $ref: '#/components/schemas/InputKey'
           type: object
         a:
-          default: 123.9
           type: number
         b:
-          default: 20
           type: integer
           format: int32
         c:
-          default: 12/20/1990
           type: string
           format: ISO8601 UTC date
           example: '2019-04-13'
@@ -216,24 +208,19 @@ components:
           type: integer
           format: int32
         f:
-          default: true
           type: boolean
       required:
         - id
-        - name
         - map
         - maps
-        - test
         - key
-        - a
         - b
-        - c
         - d
-        - f
     SMapPuttable:
       type: object
       properties:
         test:
+          default: test
           type: string
         key:
           allOf:
@@ -243,7 +230,6 @@ components:
           type: integer
           format: int32
       required:
-        - test
         - key
         - d
     SMapMultiResponse:

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,7 @@ import { IRules } from "./rules"
 const RULES = "rules.json"
 const LOCAL_RULES = lpath.join(__dirname, "library", RULES)
 
-export const VERSION = "v1.4.15"
+export const VERSION = "v1.4.16"
 
 // parse the cmd line
 const args = yargs

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -110,6 +110,12 @@ function addNamespace(
         // add to all references
         for (const attr of getAllAttributes(def)) {
             convert(attr.type, namespace, mainNamespace)
+            // complain if the attribute has default value but is not optional
+            if (attr.default && !attr.modifiers.optional) {
+                throw new Error(
+                    `Attribute ${attr.name} of ${def.name} has a default, but is not optional`
+                )
+            }
         }
 
         // convert the error references


### PR DESCRIPTION
no defaults for attributes in the following situations:

- GET, MULTIGET - why would the client want to assume a default?
- PATCH - all fields are optional, the default is just confusing at that point
- POST or PUT if the field is not optional (if you have to supply it why do you need a default - use example instead)