### PR TITLE
Default to Prod Pubsub URL

### DIFF
--- a/docs/server-blocks.md
+++ b/docs/server-blocks.md
@@ -10,7 +10,7 @@ To see how to specify the servers, look at the following example:
                 environment = PROD
         /events
             "Production Google Pubsub server"
-            server = "http://pubsub.google.com/{prefix}"
+            server = "http://pubsub.google.com"
                 environment = PROD
                 protocol = GOOGLE_PUBSUB
     }
@@ -34,7 +34,7 @@ If you don't specify any servers, the following are included by default from ./s
                 environment = PROD
         /events
             "Production Google Pubsub server"
-            server = "http://pubsub.google.com"
+            server = "https://pubsub.googleapis.com/v1/projects/liveramp-events-prod"
                 environment = PROD
                 protocol = GOOGLE_PUBSUB
     }

--- a/models/databuyer/testdata/asyncapi.expected
+++ b/models/databuyer/testdata/asyncapi.expected
@@ -5,7 +5,7 @@ info:
   version: 0.0.1
 servers:
   PROD:
-    url: 'http://pubsub.google.com'
+    url: 'https://pubsub.googleapis.com/v1/projects/liveramp-events-prod'
     protocol: GOOGLE_PUBSUB
     description: Production Google Pubsub server
 defaultContentType: application/json

--- a/models/eventing/testdata/asyncapi.expected
+++ b/models/eventing/testdata/asyncapi.expected
@@ -5,7 +5,7 @@ info:
   version: 0.0.1
 servers:
   PROD:
-    url: 'http://pubsub.google.com'
+    url: 'https://pubsub.googleapis.com/v1/projects/liveramp-events-prod'
     protocol: GOOGLE_PUBSUB
     description: Production Google Pubsub server
 defaultContentType: application/json

--- a/models/file/testdata/asyncapi.expected
+++ b/models/file/testdata/asyncapi.expected
@@ -5,7 +5,7 @@ info:
   version: 1.0.0
 servers:
   PROD:
-    url: 'http://pubsub.google.com'
+    url: 'https://pubsub.googleapis.com/v1/projects/liveramp-events-prod'
     protocol: GOOGLE_PUBSUB
     description: Production Google Pubsub server
 defaultContentType: application/json

--- a/src/library/servers.reslang
+++ b/src/library/servers.reslang
@@ -6,7 +6,7 @@ servers {
             environment = PROD
     /events
         "Production Google Pubsub server"
-        server = "http://pubsub.google.com"
+        server = "https://pubsub.googleapis.com/v1/projects/liveramp-events-prod"
             environment = PROD
             protocol = GOOGLE_PUBSUB
 }


### PR DESCRIPTION
Hi Andrew, can we use the prod pubsub URL as the default? It currently defaults to an unusable junk URL.

Right now, devs have to include the server block, but it would be nice if they only had to include it when they were using non-standard urls. It came up here: https://github.com/LiveRamp/api-specs/pull/250#issuecomment-685147506