### PR TITLE
Iss 123/import ns with slashes

### DIFF
--- a/src/grammar/base.pegjs
+++ b/src/grammar/base.pegjs
@@ -26,7 +26,7 @@ parents = _ first:resname "::" names:(name "::")* {
 }
 resname = name:(("v"[0-9]+"/")?[a-zA-Z]+[a-zA-Z0-9]*) { return name.flat().join(""); }
 name = name:([a-zA-Z_]+[_a-zA-Z0-9]*) { return name.flat().join(""); }
-filename = fname:[a-zA-Z0-9_-]+  { return fname.join(""); }
+filename = fname:([a-zA-Z0-9_-]+[a-zA-Z0-9_-|\/]*)  { return fname.flat().join(""); }
 
 // descriptions
 description = "\"" _ inner:(!"\"" i:. {return i})* "\"" {


### PR DESCRIPTION
Issue: https://github.com/LiveRamp/reslang/issues/123

Not sure if it was meant to be a restriction that only peer directories can be imported, but this PR would remove that restriction.

Not ready to merge. This PR would also allow `../` in the path, which shouldn't be a security concern, but worth flagging that reslang would be able to access any file on the filesystem (node's security story is pretty bad).

(merging into the ISS-126 branch to avoid diffs -- will update once this PR is ready for review)