### PR TITLE
Clarify union description

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -409,7 +409,11 @@ Is exactly equivalent to defining C as such:
 
 ## Unions
 
-Reslang supports unions, as per the Swagger oneOf specification. The discriminator field is always called type, and it is created implicitly. The names of the union attributes are used as the string value for the type field.
+Reslang supports unions using polymorphism via OpenAPI's `allOf` keyword. You
+can think of attributes of a union as being represented as subclasses of the union
+type itself. The discriminator field is always called `type`, and it is created
+implicitly. The names of the union attributes are used as the string value for
+the type field.
 
 ```
 


### PR DESCRIPTION
Created in response to https://github.com/LiveRamp/reslang/issues/138

Clarifying documentation now that the `oneOf` keyword isn't used in generated OpenAPI specs anymore.

I wrapped the text that I changed, since I think having some line width on Markdown files makes them easier to read when the aren't rendered.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/liveramp/reslang/139)
<!-- Reviewable:end -->
