### PR TITLE
Error when no servers found

### DIFF
--- a/src/genswagger.ts
+++ b/src/genswagger.ts
@@ -62,6 +62,11 @@ export default class SwagGen extends BaseGen {
             }
         }
 
+        if (servers.length === 0)
+            throw new Error(
+                `no server found with environment "${this.environment}" (are you passing the correct value to --env?)`
+            )
+
         // model definitions
         this.formDefinitions(schemas)
 


### PR DESCRIPTION
Fixes the swagger error of generating an empty list of server blocks when the `--env` option doesn't match any servers.
Issue: https://github.com/LiveRamp/reslang/issues/120

```bash
$ ./reslang ~/code/reslang/models/servers --stdout --env JUNK
Reslang error:  no server found with environment "JUNK" (are you passing the correct value to --env?)
error Command failed with exit code 255.
```

This PR only addresses the swagger. I think asyncapi has the same problem, though the server blocks are handled a little differently