### PR TITLE
fix unsafe regex. fix getVersion limited to 1 decimal

### DIFF
--- a/src/names.ts
+++ b/src/names.ts
@@ -39,7 +39,7 @@ export function camelCase(name: string) {
     return fix
 }
 
-function removeVersion(name: string) {
+export function removeVersion(name: string) {
     return name.replace(/^v\d+[-\/]/, "")
 }
 

--- a/src/tests/names.test.ts
+++ b/src/tests/names.test.ts
@@ -2,6 +2,7 @@ import {
     pluralizeName,
     kebabCase,
     getVersion,
+    removeVersion,
     capitalizeFirst,
     lowercaseFirst,
     camelCase
@@ -59,5 +60,12 @@ describe("getVersion", () => {
 
     it("defaults to v1", () => {
         expect(getVersion("andrew")).toBe("v1")
+    })
+})
+
+describe("removeVersion", () => {
+    it("removes the version", () => {
+        expect(removeVersion("v2/andrew")).toBe("andrew")
+        expect(removeVersion("v12/andrew")).toBe("andrew")
     })
 })


### PR DESCRIPTION
regex for removeVersion and getVersion considered "unsafe" in some contexts, minimally leads to wasted cpu due to [catastrophic backtracking](https://snyk.io/blog/redos-and-catastrophic-backtracking/).

`getVersion` regex was only looking for a single digit.

added test to check for double-digit version and refactored the tests to add descriptions.