### PR TITLE
Gitignore run-reslang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 yarn-error.log
 node_modules
 dist
-run-reslang
+/run-reslang


### PR DESCRIPTION
Some (most, nowadays?) reslang installations rely on a `run-reslang` file in users' local clone of the Reslang repo. It should not be checked in, and I like being able to `git add .`, so let's gitignore it. 

Still an open problem that `git clean` will "uninstall" reslang by deleting your `run-reslang` file, but that's for another day.