### PR TITLE
Add info about max-length and min-length to reference

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -65,8 +65,10 @@ resource v1/ExampleResource {
     GET
 }
 ```
+
 This produces the following Swagger output:
-```
+
+```yaml
 ...
     ExampleResourceOutput:
       type: object


### PR DESCRIPTION
Adding description of `max-length` and `min-length`  to the reference since this feature is more likely to be discovered if it's in the reference.