### PR TITLE
Bump Dependency Versions

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4468,9 +4468,9 @@ node-fetch-h2@^2.3.0:
     http2-client "^1.2.5"
 
 node-fetch@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
-  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
I merged all of the Dependabot PRs (https://github.com/LiveRamp/reslang/pulls?q=dependabot) into a feature branch. All the tests still pass and all the commands I tried work as expected. 

```
➜  reslang git:(dependabot-bump-versions) yarn run test
yarn run v1.22.4
$ jest
 PASS  src/tests/docs.test.ts
 PASS  src/tests/names.test.ts
 PASS  src/tests/servers.test.ts
 PASS  src/tests/checkrules.test.ts
 PASS  src/tests/events.test.ts (6.772s)
 PASS  src/tests/dotviz.test.ts (6.779s)
 PASS  src/tests/parser.test.ts (6.814s)
 PASS  src/tests/swagger.test.ts (6.905s)
 PASS  src/tests/jsconschema.test.ts (7.136s)

Test Suites: 9 passed, 9 total
Tests:       137 passed, 137 total
Snapshots:   0 total
Time:        10.327s
Ran all test suites.
✨  Done in 11.51s.
```