### PR TITLE
Bump to 4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@liveramp/reslang",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "main": "index.js",
     "license": "Apache-2.0",
     "engines": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ import JsonSchemaGen from "./genjsonschema"
 const RULES = "rules.json"
 const LOCAL_RULES = lpath.join(__dirname, "library", RULES)
 
-export const VERSION = "v3.0.1"
+export const VERSION = "v4.0.1"
 
 // parse the cmd line
 const args = yargs


### PR DESCRIPTION
When I generate stuff with the latest Reslang image, I get the behavior I expect from 4.0.0 without the "generated by 4.0.0" I was hoping for. I realized I forgot to bump a constant in `main.ts`.