### PR TITLE
Remove npm installation instructions from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,24 +50,6 @@ This should bring up the options.
 <details>
   <summary>Click to see internal LiveRamp Installation options</summary>
 
-## Installing globally on your machine (for internal LiveRamp users only)
-
-There is some one-time setup required to install Reslang globally. These steps setup your machine to install JS packages from our Github Packages registry. After taking these steps, you'll be able to install any JS package we host on Github Packages with a simple `yarn global add @liveramp/<name>`
-
-1. [Create a new Github token](https://github.com/settings/tokens/new) with `read:packages` and `write:packages`. Make sure to copy the value of the token.
-2. Enable the token for SSO. There will be a button next to the new token after you create it.
-3. Put `export GITHUB_PACKAGE_TOKEN=<token>` in your profile
-4. Create this 2 line file at `~/.npmrc`
-
-```
-//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGE_TOKEN}
-@liveramp:registry=https://npm.pkg.github.com/
-```
-
-Once you've taken those steps, you can install reslang globally with `yarn global add @liveramp/reslang`. You should then be able to run `reslang` from anywhere.
-
-_(If you prefer npm to yarn, that should work exactly the same)_
-
 ## Running in Docker (for internal LiveRamp users only)
 
 Individuals who do not want to build Reslang from scratch are free to use the `reslang-docker` script which provides convenient, but limited, functionality with a reslang container.


### PR DESCRIPTION
I believe we talked about this during standup before the New Years break. 

The Reslang npm package hasn't been re-published since version 1.0.0 so this installation option won't really work. I'm fairly certain no one is relying on the npm package right now. 

Removing this installation option from the documentation will encourage new users to use an installation method that actually works and decrease the scope of Reslang stuff that we need to be responsible for. If we don't do this, we should probably add npm package publishing to the deployment process, but I really don't think that is necessary.
