### PR TITLE
fix dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,10 @@
 FROM mhart/alpine-node:12.16.1
-RUN apk update
-RUN apk upgrade
-RUN apk add bash
-RUN apk add xsel --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
+RUN apk add --update --no-cache bash
 
 WORKDIR /app/reslang
-COPY reslang .
-COPY package.json .
-COPY tsconfig.json .
-COPY yarn.lock .
+COPY reslang package.json tsconfig.json yarn.lock ./
 COPY src ./src/
 
-RUN yarn install
+RUN yarn install --frozen-lockfile --non-interactive
 
 ENTRYPOINT ["./reslang"]


### PR DESCRIPTION
PR and Master builds are failing because a linux package used in the Dockerfile
is no longer available.

e.g.
https://console.cloud.google.com/cloud-build/builds/3f2542fc-ad45-432c-a762-dc3f427878aa;step=0?project=liveramp-eng-api-dev

That package was unstable, so it should not have been used, but it turns out it
doesn't need to be used at all. It was being used to help copy to clipboard
inside a docker container, which doesn't make much sense. I removed the
dependency entirely and everything seems to work just fine. I built a new
docker image with this change and used the `reslang-docker` script as well as
api-spec's `generate-specs` scripts with it.
