### PR TITLE
APIE-9: Prevent reslang from creating an invalid schema for custom events

### DIFF
--- a/models/eventing/events.reslang
+++ b/models/eventing/events.reslang
@@ -52,7 +52,7 @@ event StartSignal {
     /payload
         name: string
         address: string[1..10]
-        // foo: value-of v2/TestResource::Foo2 ==> causes event generation to not render correctly, need to find out why
+        foo: value-of v2/TestResource::Foo2
 }
 produces StartSignal
 

--- a/models/eventing/testdata/asyncapi.expected
+++ b/models/eventing/testdata/asyncapi.expected
@@ -242,6 +242,39 @@ components:
         - id
         - address
       description: A REST subresource
+    v2TestResourceFoo2Header:
+      type: object
+      properties:
+        verb:
+          description: ''
+          type: string
+        location:
+          description: ''
+          type: string
+          format: url
+          example: 'https://www.domain.com (url)'
+        ids:
+          description: ''
+          items:
+            type: string
+          type: array
+      required:
+        - verb
+        - location
+        - ids
+    v2TestResourceFoo2Output:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        address:
+          items:
+            type: string
+          type: array
+      required:
+        - id
+        - address
     StartSignalHeader:
       type: object
       properties:
@@ -268,9 +301,13 @@ components:
           minItems: 1
           maxItems: 10
           type: array
+        foo:
+          $ref: '#/components/schemas/v2TestResourceFoo2Output'
+          type: object
       required:
         - name
         - address
+        - foo
       description: Event to start
     v3StopSignalHeader:
       type: object
@@ -365,6 +402,27 @@ components:
             type: string
             enum:
               - POST
+          location:
+            description: ''
+            type: string
+            format: url
+            example: 'https://www.domain.com (url)'
+          ids:
+            description: ''
+            items:
+              type: string
+            type: array
+        required:
+          - verb
+          - location
+          - ids
+    v2TestResourceFoo2Header:
+      headers:
+        type: object
+        properties:
+          verb:
+            description: ''
+            type: string
           location:
             description: ''
             type: string

--- a/src/genevents.ts
+++ b/src/genevents.ts
@@ -180,21 +180,12 @@ export default class EventsGen extends BaseGen {
 
     private addStandardHeaderDefinition(schemas: any, el: IResourceLike) {
         const name = camelCase(this.formSingleUniqueName(el)) + "Header"
-
-        // form the array of event verbs
-        const verbs: string[] = []
-        for (const op of el.events || []) {
-            verbs.push(op.operation)
-        }
+        const verb = this.buildVerbProperty(el);
 
         schemas[name] = {
             type: "object",
             properties: {
-                verb: {
-                    description: "",
-                    type: "string",
-                    enum: verbs
-                },
+                verb: verb,
                 location: {
                     description: "",
                     type: "string",
@@ -212,6 +203,21 @@ export default class EventsGen extends BaseGen {
             required: ["verb", "location", "ids"]
         }
         return name
+    }
+
+    public buildVerbProperty(el: IResourceLike) {
+        const verbs: string[] = []
+        for (const op of el.events || []) {
+            verbs.push(op.operation)
+        }
+        return verbs.length > 0 ? {
+            description: "",
+            type: "string",
+            "enum": verbs
+        } : {
+            description: "",
+            type: "string",
+        };
     }
 
     private liftToHeader(name: string, schemas: any, headers: any) {


### PR DESCRIPTION
jira: APIE-9
github: https://github.com/LiveRamp/reslang/issues/183

Prevent reslang from including `enum: []` in property verb