### PR TITLE
fixup: SyntaxError: Error resolving $ref pointer

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,3 +1,7 @@
+## 6.2.2 11/05/2021
+
+- Fix `SyntaxError: Error resolving $ref pointer` when generating swagger/asyncapi using resourcelike attributes.
+
 ## 6.2.1 11/05/2021
 
 - Add `nullable`: Added support to generate nullable attributes in schemas for swagger specs.

--- a/models/eventing/events.reslang
+++ b/models/eventing/events.reslang
@@ -52,6 +52,7 @@ event StartSignal {
     /payload
         name: string
         address: string[1..10]
+        // The followin should appear in refs as v2TestResourceFoo2Output
         foo: value-of v2/TestResource::Foo2
 }
 produces StartSignal

--- a/models/eventing/testdata/asyncapi.expected
+++ b/models/eventing/testdata/asyncapi.expected
@@ -302,7 +302,7 @@ components:
           maxItems: 10
           type: array
         foo:
-          $ref: '#/components/schemas/v2TestResourceFoo2'
+          $ref: '#/components/schemas/v2TestResourceFoo2Output'
           type: object
       required:
         - name

--- a/models/resourcelike-attribute/diagram.reslang
+++ b/models/resourcelike-attribute/diagram.reslang
@@ -1,0 +1,1 @@
+diagram main {}

--- a/models/resourcelike-attribute/main.reslang
+++ b/models/resourcelike-attribute/main.reslang
@@ -1,0 +1,23 @@
+" Test for subresources
+Reslang generates `Output` and `Input` schema for each of the
+resource-like definitions it receives in any given *.reslang file.
+
+Currently it only tests attribues of type `value-of <subresource>`
+TODO: Other resourcelike attributes.
+"
+namespace test/resourcelike-attribute {
+    title "Resource-like attributes test"
+    version 0.0.1
+}
+
+resource UpperResource {
+    id: string
+    subresource: value-of UpperResource::LowerResource
+
+    /operations
+      GET
+}
+
+subresource UpperResource::LowerResource {
+    name: string
+}

--- a/models/resourcelike-attribute/testdata/asyncapi.expected
+++ b/models/resourcelike-attribute/testdata/asyncapi.expected
@@ -1,0 +1,1 @@
+Error: No events are listed in the specification

--- a/models/resourcelike-attribute/testdata/dotviz.expected
+++ b/models/resourcelike-attribute/testdata/dotviz.expected
@@ -1,0 +1,14 @@
+digraph G {
+graph [fontname = "helvetica"];
+node [fontname = "helvetica"];
+edge [fontname = "helvetica"];
+node [shape=none];
+
+"UpperResource" [label=<
+<table border="3" cellborder="0" cellspacing="1" style='rounded' bgcolor='#ffffcc'>
+<tr><td><b>UpperResource </b></td></tr><hr/><tr><td align="left">id: string</td></tr><tr><td align="left">subresource: LowerResource</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> GET</font></td></tr></table>>];
+"UpperResource::LowerResource" [label=<
+<table border="1" cellborder="0" cellspacing="1" style='rounded' >
+<tr><td><b>LowerResource </b></td></tr><hr/><tr><td align="left">name: string</td></tr></table>>];
+"UpperResource" -> "UpperResource::LowerResource" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
+}

--- a/models/resourcelike-attribute/testdata/jsonschema.expected
+++ b/models/resourcelike-attribute/testdata/jsonschema.expected
@@ -1,0 +1,56 @@
+{
+  "$id": "https://schemas.liveramp.com/noroot",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "UpperResourceOutput": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "subresource": {
+          "$ref": "#/definitions/UpperResourceLowerResourceOutput",
+          "type": "object"
+        }
+      },
+      "required": [
+        "id",
+        "subresource"
+      ]
+    },
+    "UpperResourceLowerResourceOutput": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "StandardError": {
+      "type": "object",
+      "properties": {
+        "httpStatus": {
+          "description": "HTTP error status code for this problem",
+          "type": "integer",
+          "format": "int32"
+        },
+        "errorCode": {
+          "description": "Service specific error code, more granular",
+          "type": "string"
+        },
+        "message": {
+          "description": "General, human readable error message",
+          "type": "string"
+        }
+      },
+      "required": [
+        "httpStatus",
+        "errorCode",
+        "message"
+      ]
+    }
+  }
+}

--- a/models/resourcelike-attribute/testdata/parsed.expected
+++ b/models/resourcelike-attribute/testdata/parsed.expected
@@ -1,0 +1,287 @@
+[
+  {
+    "definitions": [
+      {
+        "attributes": [
+          {
+            "constraints": {},
+            "full": false,
+            "inline": false,
+            "linked": false,
+            "modifiers": {
+              "flag": false,
+              "mutable": false,
+              "nullable": false,
+              "optional": false,
+              "optionalGet": false,
+              "optionalPost": false,
+              "optionalPut": false,
+              "output": false,
+              "query": false,
+              "queryonly": false,
+              "representation": false
+            },
+            "name": "id",
+            "stringMap": false,
+            "type": {
+              "name": "string",
+              "parentName": "",
+              "parentShort": "",
+              "parents": [],
+              "short": "string"
+            }
+          },
+          {
+            "constraints": {},
+            "full": true,
+            "inline": false,
+            "linked": false,
+            "modifiers": {
+              "flag": false,
+              "mutable": false,
+              "nullable": false,
+              "optional": false,
+              "optionalGet": false,
+              "optionalPost": false,
+              "optionalPut": false,
+              "output": false,
+              "query": false,
+              "queryonly": false,
+              "representation": false
+            },
+            "name": "subresource",
+            "stringMap": false,
+            "type": {
+              "name": "UpperResource::LowerResource",
+              "parentName": "UpperResource",
+              "parentShort": "UpperResource",
+              "parents": [
+                "UpperResource"
+              ],
+              "short": "LowerResource"
+            }
+          }
+        ],
+        "category": "definition",
+        "file": "main.reslang",
+        "future": false,
+        "kind": "resource-like",
+        "name": "UpperResource",
+        "namespace": "",
+        "operations": [
+          {
+            "errors": [],
+            "operation": "GET",
+            "options": [],
+            "summary": ""
+          }
+        ],
+        "parentName": "",
+        "parentShort": "",
+        "parents": [],
+        "secondary": false,
+        "short": "UpperResource",
+        "singleton": false,
+        "type": "resource"
+      },
+      {
+        "attributes": [
+          {
+            "constraints": {},
+            "full": false,
+            "inline": false,
+            "linked": false,
+            "modifiers": {
+              "flag": false,
+              "mutable": false,
+              "nullable": false,
+              "optional": false,
+              "optionalGet": false,
+              "optionalPost": false,
+              "optionalPut": false,
+              "output": false,
+              "query": false,
+              "queryonly": false,
+              "representation": false
+            },
+            "name": "name",
+            "stringMap": false,
+            "type": {
+              "name": "string",
+              "parentName": "",
+              "parentShort": "",
+              "parents": [],
+              "short": "string"
+            }
+          }
+        ],
+        "category": "definition",
+        "file": "main.reslang",
+        "future": false,
+        "kind": "resource-like",
+        "name": "UpperResource::LowerResource",
+        "parentName": "UpperResource",
+        "parentShort": "UpperResource",
+        "parents": [
+          "UpperResource"
+        ],
+        "secondary": false,
+        "short": "LowerResource",
+        "singleton": false,
+        "type": "subresource"
+      }
+    ],
+    "diagrams": [],
+    "docs": [],
+    "imports": [],
+    "namespace": [
+      {
+        "category": "namespace",
+        "comment": "Test for subresources\nReslang generates `Output` and `Input` schema for each of the\nresource-like definitions it receives in any given *.reslang file.\n\nCurrently it only tests attribues of type `value-of <subresource>`\nTODO: Other resourcelike attributes.",
+        "space": "test/resourcelike-attribute",
+        "title": "Resource-like attributes test",
+        "version": "0.0.1"
+      }
+    ],
+    "servers": [],
+    "tags": []
+  },
+  {
+    "definitions": [
+      {
+        "attributes": [
+          {
+            "comment": "HTTP error status code for this problem",
+            "constraints": {},
+            "full": false,
+            "inline": false,
+            "linked": false,
+            "modifiers": {
+              "flag": false,
+              "mutable": false,
+              "nullable": false,
+              "optional": false,
+              "optionalGet": false,
+              "optionalPost": false,
+              "optionalPut": false,
+              "output": false,
+              "query": false,
+              "queryonly": false,
+              "representation": false
+            },
+            "name": "httpStatus",
+            "stringMap": false,
+            "type": {
+              "name": "int",
+              "parentName": "",
+              "parentShort": "",
+              "parents": [],
+              "short": "int"
+            }
+          },
+          {
+            "comment": "Service specific error code, more granular",
+            "constraints": {},
+            "full": false,
+            "inline": false,
+            "linked": false,
+            "modifiers": {
+              "flag": false,
+              "mutable": false,
+              "nullable": false,
+              "optional": false,
+              "optionalGet": false,
+              "optionalPost": false,
+              "optionalPut": false,
+              "output": false,
+              "query": false,
+              "queryonly": false,
+              "representation": false
+            },
+            "name": "errorCode",
+            "stringMap": false,
+            "type": {
+              "name": "string",
+              "parentName": "",
+              "parentShort": "",
+              "parents": [],
+              "short": "string"
+            }
+          },
+          {
+            "comment": "General, human readable error message",
+            "constraints": {},
+            "full": false,
+            "inline": false,
+            "linked": false,
+            "modifiers": {
+              "flag": false,
+              "mutable": false,
+              "nullable": false,
+              "optional": false,
+              "optionalGet": false,
+              "optionalPost": false,
+              "optionalPut": false,
+              "output": false,
+              "query": false,
+              "queryonly": false,
+              "representation": false
+            },
+            "name": "message",
+            "stringMap": false,
+            "type": {
+              "name": "string",
+              "parentName": "",
+              "parentShort": "",
+              "parents": [],
+              "short": "string"
+            }
+          }
+        ],
+        "category": "definition",
+        "file": "local.reslang",
+        "kind": "structure",
+        "name": "StandardError",
+        "parentName": "",
+        "parentShort": "",
+        "parents": [],
+        "secondary": false,
+        "short": "StandardError",
+        "type": "structure"
+      }
+    ],
+    "diagrams": [],
+    "docs": [],
+    "imports": [],
+    "namespace": [],
+    "servers": [],
+    "tags": []
+  },
+  {
+    "definitions": [],
+    "diagrams": [],
+    "docs": [],
+    "imports": [],
+    "namespace": [],
+    "servers": [
+      {
+        "category": "servers",
+        "events": [
+          {
+            "comment": "Production Google Pubsub server",
+            "environment": "PROD",
+            "protocol": "GOOGLE_PUBSUB",
+            "url": "https://pubsub.googleapis.com/v1/projects/liveramp-events-prod"
+          }
+        ],
+        "rest": [
+          {
+            "environment": "PROD",
+            "url": "https://api.liveramp.com"
+          }
+        ]
+      }
+    ],
+    "tags": []
+  }
+]

--- a/models/resourcelike-attribute/testdata/parsed.expected
+++ b/models/resourcelike-attribute/testdata/parsed.expected
@@ -1,5 +1,20 @@
 [
   {
+    "definitions": [],
+    "diagrams": [
+      {
+        "category": "diagram",
+        "diagram": "main",
+        "groups": []
+      }
+    ],
+    "docs": [],
+    "imports": [],
+    "namespace": [],
+    "servers": [],
+    "tags": []
+  },
+  {
     "definitions": [
       {
         "attributes": [

--- a/models/resourcelike-attribute/testdata/swagger.expected
+++ b/models/resourcelike-attribute/testdata/swagger.expected
@@ -1,31 +1,39 @@
 openapi: 3.0.1
 info:
-  title: project A
-  description: ''
+  title: Resource-like attributes test
+  description: |-
+    Test for subresources
+    Reslang generates `Output` and `Input` schema for each of the
+    resource-like definitions it receives in any given *.reslang file.
+
+    Currently it only tests attribues of type `value-of <subresource>`
+    TODO: Other resourcelike attributes.
   version: 0.0.1
 servers:
   - description: ''
-    url: 'https://api.liveramp.com/projecta'
+    url: 'https://api.liveramp.com/test/resourcelike-attribute'
 tags:
-  - name: ReeSource
+  - name: UpperResource
     description: '(resource)  '
+  - name: 'UpperResource::LowerResource'
+    description: '(subresource)  '
 paths:
-  '/v1/ree-sources/{id}':
+  '/v1/upper-resources/{id}':
     get:
       tags:
-        - ReeSource
-      operationId: Get ReeSource
+        - UpperResource
+      operationId: Get UpperResource
       description: ''
-      summary: Get ReeSource
+      summary: Get UpperResource
       responses:
         '200':
-          description: ReeSource retrieved successfully
+          description: UpperResource retrieved successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ReeSourceOutput'
+                $ref: '#/components/schemas/UpperResourceOutput'
         '404':
-          description: ReeSource not found
+          description: UpperResource not found
           content:
             application/json:
               schema:
@@ -39,21 +47,25 @@ paths:
 components:
   parameters: {}
   schemas:
-    ReeSourceOutput:
+    UpperResourceOutput:
       type: object
       properties:
         id:
           type: string
-        referenceB:
-          items:
-            type: string
-          minItems: 2
-          maxItems: 2
-          type: array
-          description: 'Link to project_B.Top::Sub resource via [topId, subId]'
+        subresource:
+          allOf:
+            - $ref: '#/components/schemas/UpperResourceLowerResourceOutput'
+          type: object
       required:
         - id
-        - referenceB
+        - subresource
+    UpperResourceLowerResourceOutput:
+      type: object
+      properties:
+        name:
+          type: string
+      required:
+        - name
     StandardError:
       type: object
       properties:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@liveramp/reslang",
-    "version": "6.2.1",
+    "version": "6.2.2",
     "main": "index.js",
     "license": "Apache-2.0",
     "engines": {

--- a/src/genbase.ts
+++ b/src/genbase.ts
@@ -1164,7 +1164,11 @@ Actions cannot have subresources`
                     if (attr.linked) {
                         this.addLinkedType(def, schema, attr)
                     } else if (attr.full) {
-                        this.setSchemaRefs(schema, name)
+                        // TOOD: formalize a function to obtain a schema ref from a reslang definition.
+                        //       for now it seems some places append "Output" to their references
+                        //       likely this is special logic for "resource-like" kinds.
+                        let fullAttrSchemaRef = `${name}Output`
+                        this.setSchemaRefs(schema, fullAttrSchemaRef)
                         schema.type = "object"
                     } else {
                         throw new Error(

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ import JsonSchemaGen from "./genjsonschema"
 const RULES = "rules.json"
 const LOCAL_RULES = lpath.join(__dirname, "library", RULES)
 
-export const VERSION = "v6.2.1"
+export const VERSION = "v6.2.2"
 
 // parse the cmd line
 const args = yargs

--- a/src/tests/allmodels.ts
+++ b/src/tests/allmodels.ts
@@ -1,5 +1,6 @@
 // these are all the models we want to generate specs for, and to check
 export const allModels = [
+    "resourcelike-attribute",
     "authorization",
     "checkrules",
     "complex-resource",

--- a/src/tests/swagger.test.ts
+++ b/src/tests/swagger.test.ts
@@ -1,8 +1,7 @@
-import { readFile, clean } from "../parse"
-import { strip } from "./utilities"
+import {clean, readFile} from "../parse"
 import SwagGen from "../genswagger"
 import yaml from "js-yaml"
-import { allModels } from "./allmodels"
+import {allModels} from "./allmodels"
 
 /** swagger generation tests
  */
@@ -21,12 +20,9 @@ function compare(module: string) {
         "",
         true
     )
-    const swagger = swag.generate()
+    const got = swag.generate();
+    const expected = yaml.load(readFile(`models/${module}/testdata/swagger.expected`));
 
-    const got = strip(yaml.dump(clean(swagger), { noRefs: true }))
-    const expected = strip(
-        readFile(`models/${module}/testdata/swagger.expected`)
-    )
-
-    expect(got).toBe(expected)
+    expect(yaml.dump(clean(got), {noRefs: true}))
+        .toStrictEqual(yaml.dump(clean(expected), {noRefs: true}))
 }


### PR DESCRIPTION
fixup: Schema refs to resources should include `Output` suffix

Introduced in #215 

* Updated swagger test to output formatted differences
* Reformat: models/imported-subresources/project_A/testdata/swagger.expected
* Add test case / model folder for this error with swagger output (eventing test already caught this for asyncapi)