### PR TITLE
APIE-143 multiverb response id bug/subresource diagram background

### DIFF
--- a/models/checkrules/testdata/dotviz.expected
+++ b/models/checkrules/testdata/dotviz.expected
@@ -8,23 +8,23 @@ digraph G {
                     <table border="3" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>A        </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="left">name: string</td></tr><tr><td align="left">outputName: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> POST GET</font></td></tr></table>>];
 "A::B" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  >
+                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>B        </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="left">name: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> POST GET</font></td></tr></table>>];
 "A" -> "A::B" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 "A::B::C" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  >
+                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>C        </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="left">name: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> POST GET</font></td></tr></table>>];
 "A::B" -> "A::B::C" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 "A::B::C::start" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  >
+                    <table border="1" cellborder="0" cellspacing="1" style='rounded' >
                     <tr><td><b>start        </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="left">name: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> POST GET</font></td></tr></table>>];
 "A::B::C" -> "A::B::C::start" [dir="none" label=< <font point-size="8">action</font> >];
 "A::B::stop" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  >
+                    <table border="1" cellborder="0" cellspacing="1" style='rounded' >
                     <tr><td><b>stop        </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="left">name: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> POST GET</font></td></tr></table>>];
 "A::B" -> "A::B::stop" [dir="none" label=< <font point-size="8">action</font> >];
 "A::B::stop::Deep" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  >
+                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>Deep        </b></td></tr><hr/><tr><td align="left">id: int</td></tr></table>>];
 "A::B::stop" -> "A::B::stop::Deep" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 "Asset" [label=<

--- a/models/complex-resource/testdata/dotviz.expected
+++ b/models/complex-resource/testdata/dotviz.expected
@@ -1,48 +1,48 @@
 digraph G {
-        graph [fontname = "helvetica"];
-        node [fontname = "helvetica"];
-        edge [fontname = "helvetica"];
-        node [shape=none];
-        
+graph [fontname = "helvetica"];
+node [fontname = "helvetica"];
+edge [fontname = "helvetica"];
+node [shape=none];
+
 "simple-resource.Garage" [label=<
-                    <table border="3" cellborder="0" cellspacing="1" style='rounded' color='gray' bgcolor='#ffffcc'>
-                    <tr><td><b>Garage        </b></td></tr><hr/><tr><td align="left">id: string</td></tr><tr><td align="left">name: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> PUT POST GET DELETE MULTIGET id name</font></td></tr></table>>];
+<table border="3" cellborder="0" cellspacing="1" style='rounded' color='gray' bgcolor='#ffffcc'>
+<tr><td><b>Garage </b></td></tr><hr/><tr><td align="left">id: string</td></tr><tr><td align="left">name: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> PUT POST GET DELETE MULTIGET id name</font></td></tr></table>>];
 "simple-resource.Manufacturer" [label=<
-                    <table border="1" cellborder="0" cellspacing="1"  color='gray' >
-                    <tr><td><b>Manufacturer        </b></td></tr>        <hr/><tr><td align="left">company: string</td></tr><tr><td align="left">home: url</td></tr><tr><td align="left">homeArray: url[]</td></tr><tr><td align="left">timeToManufacture: duration</td></tr><tr><td align="left">other: url</td></tr><tr><td align="left">other2: uri</td></tr></table> >];
+<table border="1" cellborder="0" cellspacing="1" color='gray' >
+<tr><td><b>Manufacturer </b></td></tr> <hr/><tr><td align="left">company: string</td></tr><tr><td align="left">home: url</td></tr><tr><td align="left">homeArray: url[]</td></tr><tr><td align="left">timeToManufacture: duration</td></tr><tr><td align="left">other: url</td></tr><tr><td align="left">other2: uri</td></tr></table> >];
 "simple-resource.Foo" [label=<
-                    <table border="3" cellborder="0" cellspacing="1" style='rounded' color='gray' bgcolor='#ffffcc'>
-                    <tr><td><b>Foo        </b></td></tr><hr/><tr><td align="left">a: int</td></tr><tr><td align="left">b: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8">singleton  PUT GET</font></td></tr></table>>];
+<table border="3" cellborder="0" cellspacing="1" style='rounded' color='gray' bgcolor='#ffffcc'>
+<tr><td><b>Foo </b></td></tr><hr/><tr><td align="left">a: int</td></tr><tr><td align="left">b: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8">singleton PUT GET</font></td></tr></table>>];
 "simple-resource.Foo::Subfoo" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded' color='gray' bgcolor='#ffffcc'>
-                    <tr><td><b>Subfoo        </b></td></tr><hr/><tr><td align="left">id: string</td></tr></table>>];
+<table border="1" cellborder="0" cellspacing="1" style='rounded' color='gray' bgcolor='#ffffcc'>
+<tr><td><b>Subfoo </b></td></tr><hr/><tr><td align="left">id: string</td></tr></table>>];
 "simple-resource.Foo" -> "simple-resource.Foo::Subfoo" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 "simple-resource.Foo::Subfoo::Subsubfoo" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded' color='gray' bgcolor='#ffffcc'>
-                    <tr><td><b>Subsubfoo        </b></td></tr><hr/><tr><td align="left">id: string</td></tr></table>>];
+<table border="1" cellborder="0" cellspacing="1" style='rounded' color='gray' bgcolor='#ffffcc'>
+<tr><td><b>Subsubfoo </b></td></tr><hr/><tr><td align="left">id: string</td></tr></table>>];
 "simple-resource.Foo::Subfoo" -> "simple-resource.Foo::Subfoo::Subsubfoo" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 "simple-resource.Bar" [label=<
-                    <table border="3" cellborder="0" cellspacing="1" style='rounded' color='gray' bgcolor='#ffffcc'>
-                    <tr><td><b>Bar        </b></td></tr><hr/><tr><td align="left">name: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> MULTIGET name</font></td></tr></table>>];
+<table border="3" cellborder="0" cellspacing="1" style='rounded' color='gray' bgcolor='#ffffcc'>
+<tr><td><b>Bar </b></td></tr><hr/><tr><td align="left">name: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> MULTIGET name</font></td></tr></table>>];
 "simple-resource.Test" [label=<
-                    <table border="3" cellborder="0" cellspacing="1" style='rounded' color='gray' bgcolor='#ffffcc'>
-                    <tr><td><b>Test        </b></td></tr><hr/><tr><td align="left">name: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> POST</font></td></tr></table>>];
+<table border="3" cellborder="0" cellspacing="1" style='rounded' color='gray' bgcolor='#ffffcc'>
+<tr><td><b>Test </b></td></tr><hr/><tr><td align="left">name: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> POST</font></td></tr></table>>];
 "Car" [label=<
-                    <table border="3" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
-                    <tr><td><b>Car        </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="left">bought: date (out)</td></tr><tr><td align="left">brand: BrandEnum</td></tr><tr><td align="left">view: ViewEnum</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> POST GET MULTIGET id brand</font></td></tr></table>>];
+<table border="3" cellborder="0" cellspacing="1" style='rounded' bgcolor='#ffffcc'>
+<tr><td><b>Car </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="left">bought: date (out)</td></tr><tr><td align="left">brand: BrandEnum</td></tr><tr><td align="left">view: ViewEnum</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> POST GET MULTIGET id brand</font></td></tr></table>>];
 "ViewEnum" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" >
-                    <tr><td align="left"><b>ViewEnum  </b></td></tr><hr/><tr><td align="left">FULL</td></tr><tr><td align="left">BRIEF</td></tr></table>>];
+<table border="1" cellborder="0" cellspacing="1" >
+<tr><td align="left"><b>ViewEnum </b></td></tr><hr/><tr><td align="left">FULL</td></tr><tr><td align="left">BRIEF</td></tr></table>>];
 "Specification" [label=<
-                    <table border="1" cellborder="0" cellspacing="1"   >
-                    <tr><td><b>Specification        </b></td></tr>        <hr/><tr><td align="left">type: string</td></tr><tr><td align="left">documentation: string</td></tr></table> >];
+<table border="1" cellborder="0" cellspacing="1" >
+<tr><td><b>Specification </b></td></tr> <hr/><tr><td align="left">type: string</td></tr><tr><td align="left">documentation: string</td></tr></table> >];
 "Car::Wheel" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
-                    <tr><td><b>Wheel        </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="left">radius: double</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> GET PUT POST MULTIGET id</font></td></tr></table>>];
+<table border="1" cellborder="0" cellspacing="1" style='rounded' bgcolor='#ffffcc'>
+<tr><td><b>Wheel </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="left">radius: double</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> GET PUT POST MULTIGET id</font></td></tr></table>>];
 "Car" -> "Car::Wheel" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 "BrandEnum" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" >
-                    <tr><td align="left"><b>BrandEnum  </b></td></tr><hr/><tr><td align="left">TOYOTA</td></tr><tr><td align="left">FORD</td></tr></table>>];
+<table border="1" cellborder="0" cellspacing="1" >
+<tr><td align="left"><b>BrandEnum </b></td></tr><hr/><tr><td align="left">TOYOTA</td></tr><tr><td align="left">FORD</td></tr></table>>];
 "simple-resource.Garage" -> "simple-resource.Manufacturer" [dir="back" arrowtail="diamond" label=< <font point-size="8"> manufacturer</font> >];
 "Car" -> "Specification" [dir="back" arrowtail="diamond" label=< <font point-size="8"> engine</font> >];
 "Car" -> "Specification" [dir="back" arrowtail="diamond" label=< <font point-size="8"> components</font> >];

--- a/models/complex-resource/testdata/dotviz.expected
+++ b/models/complex-resource/testdata/dotviz.expected
@@ -14,11 +14,11 @@ digraph G {
                     <table border="3" cellborder="0" cellspacing="1" style='rounded' color='gray' bgcolor='#ffffcc'>
                     <tr><td><b>Foo        </b></td></tr><hr/><tr><td align="left">a: int</td></tr><tr><td align="left">b: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8">singleton  PUT GET</font></td></tr></table>>];
 "simple-resource.Foo::Subfoo" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded' color='gray' >
+                    <table border="1" cellborder="0" cellspacing="1" style='rounded' color='gray' bgcolor='#ffffcc'>
                     <tr><td><b>Subfoo        </b></td></tr><hr/><tr><td align="left">id: string</td></tr></table>>];
 "simple-resource.Foo" -> "simple-resource.Foo::Subfoo" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 "simple-resource.Foo::Subfoo::Subsubfoo" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded' color='gray' >
+                    <table border="1" cellborder="0" cellspacing="1" style='rounded' color='gray' bgcolor='#ffffcc'>
                     <tr><td><b>Subsubfoo        </b></td></tr><hr/><tr><td align="left">id: string</td></tr></table>>];
 "simple-resource.Foo::Subfoo" -> "simple-resource.Foo::Subfoo::Subsubfoo" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 "simple-resource.Bar" [label=<
@@ -37,7 +37,7 @@ digraph G {
                     <table border="1" cellborder="0" cellspacing="1"   >
                     <tr><td><b>Specification        </b></td></tr>        <hr/><tr><td align="left">type: string</td></tr><tr><td align="left">documentation: string</td></tr></table> >];
 "Car::Wheel" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  >
+                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>Wheel        </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="left">radius: double</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> GET PUT POST MULTIGET id</font></td></tr></table>>];
 "Car" -> "Car::Wheel" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 "BrandEnum" [label=<

--- a/models/direct2dist/testdata/dotviz.expected
+++ b/models/direct2dist/testdata/dotviz.expected
@@ -52,7 +52,7 @@ digraph G {
                     <table border="3" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>Destination        </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="right"><font color="#0000ff" point-size="8">FUTURE </font></td></tr></table>>];
 "Destination::Endpoint" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  >
+                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>Endpoint        </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="right"><font color="#0000ff" point-size="8">FUTURE </font></td></tr></table>>];
 "Destination" -> "Destination::Endpoint" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 "DistributionRequest" -> "Destination::Endpoint" [label=< <font point-size="8"> destinationEndpointId</font> > arrowhead="vee"];

--- a/models/distribution/testdata/dotviz.expected
+++ b/models/distribution/testdata/dotviz.expected
@@ -8,11 +8,11 @@ digraph G {
                     <table border="3" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>Destination        </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="left">name: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> POST GET MULTIGET name</font></td></tr></table>>];
 "Destination::TaxonomyConfiguration" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  >
+                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>TaxonomyConfiguration        </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="left">name: string</td></tr><tr><td align="left">mappingsMacro: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> POST PUT GET MULTIGET id</font></td></tr></table>>];
 "Destination" -> "Destination::TaxonomyConfiguration" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 "Destination::Integration" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  >
+                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>Integration        </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="left">name: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> POST PUT GET MULTIGET name</font></td></tr></table>>];
 "Destination" -> "Destination::Integration" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 "IdentifierTypeMapping" [label=<
@@ -22,22 +22,22 @@ digraph G {
                     <table border="3" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>IdentifierPool        </b></td></tr><hr/><tr><td align="left">id: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8">FUTURE </font></td></tr></table>>];
 "Destination::Endpoint" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  >
+                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>Endpoint        </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="left">name: string</td></tr><tr><td align="left">url: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> POST PUT GET MULTIGET name</font></td></tr></table>>];
 "Destination" -> "Destination::Endpoint" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 "EndpointProperty" [label=<
                     <table border="1" cellborder="0" cellspacing="1"   >
                     <tr><td><b>EndpointProperty        </b></td></tr>        <hr/><tr><td align="left">name: string</td></tr><tr><td align="left">default: string</td></tr><tr><td align="left">externallyConfigurable: boolean</td></tr></table> >];
 "Destination::Packager" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  >
+                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>Packager        </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="left">macro: string</td></tr><tr><td align="left">compressionType: CompressionTypeEnum</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> POST GET MULTIGET</font></td></tr></table>>];
 "Destination" -> "Destination::Packager" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 "Destination::Formatter" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  >
+                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>Formatter        </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="left">macro: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> POST GET MULTIGET</font></td></tr></table>>];
 "Destination" -> "Destination::Formatter" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 "Destination::Deliverer" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  >
+                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>Deliverer        </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="left">protocol: ProtocolEnum</td></tr><tr><td align="left">macro: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> POST GET MULTIGET</font></td></tr></table>>];
 "Destination" -> "Destination::Deliverer" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 "CompressionTypeEnum" [label=<

--- a/models/eventing/testdata/dotviz.expected
+++ b/models/eventing/testdata/dotviz.expected
@@ -14,7 +14,7 @@ digraph G {
                     <table border="3" cellborder="0" cellspacing="1" style='rounded' color='gray' bgcolor='#ffffcc'>
                     <tr><td><b>Specification        </b></td></tr><hr/><tr><td align="left">id: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8">FUTURE </font></td></tr></table>>];
 "file.Directory::File" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded' color='gray' >
+                    <table border="1" cellborder="0" cellspacing="1" style='rounded' color='gray' bgcolor='#ffffcc'>
                     <tr><td><b>File        </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="left">name: string</td></tr><tr><td align="left">url: string</td></tr><tr><td align="left">contents: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> GET POST MULTIGET contents</font></td></tr></table>>];
 "file.Directory" -> "file.Directory::File" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 "file.DirectoryDeleteRequest" [label=<
@@ -37,11 +37,11 @@ digraph G {
                     <table border="3" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>v2/TestResource        </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="left">name: string</td></tr><tr><td align="left">number: int</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> POST GET</font></td></tr></table>>];
 "v2/TestResource::Foo" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  >
+                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>Foo        </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="left">address: string[]</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> POST</font></td></tr></table>>];
 "v2/TestResource" -> "v2/TestResource::Foo" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 "v2/TestResource::Foo2" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  >
+                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>Foo2        </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="left">address: string[]</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> POST GET</font></td></tr></table>>];
 "v2/TestResource" -> "v2/TestResource::Foo2" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 "StartSignal" [label=<

--- a/models/file/testdata/dotviz.expected
+++ b/models/file/testdata/dotviz.expected
@@ -14,7 +14,7 @@ digraph G {
                     <table border="3" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>Specification        </b></td></tr><hr/><tr><td align="left">id: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8">FUTURE </font></td></tr></table>>];
 "Directory::File" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  >
+                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>File        </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="left">name: string</td></tr><tr><td align="left">url: string</td></tr><tr><td align="left">contents: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> GET POST MULTIGET contents</font></td></tr></table>>];
 "Directory" -> "Directory::File" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 "DirectoryDeleteRequest" [label=<

--- a/models/imported-subresources/project_A/testdata/dotviz.expected
+++ b/models/imported-subresources/project_A/testdata/dotviz.expected
@@ -8,7 +8,7 @@ digraph G {
     <table border="3" cellborder="0" cellspacing="1" style='rounded' color='gray' bgcolor='#ffffcc'>
     <tr><td><b>Top </b></td></tr><hr/><tr><td align="left">id: string</td></tr></table>>];
     "project_B.Top::Sub" [label=<
-    <table border="1" cellborder="0" cellspacing="1" style='rounded' color='gray' >
+    <table border="1" cellborder="0" cellspacing="1" style='rounded' color='gray' bgcolor='#ffffcc'>
     <tr><td><b>Sub </b></td></tr><hr/><tr><td align="left">id: string</td></tr><tr><td align="left">isCool: boolean</td></tr></table>>];
     "project_B.Top" -> "project_B.Top::Sub" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
     "ReeSource" [label=<

--- a/models/linked/testdata/dotviz.expected
+++ b/models/linked/testdata/dotviz.expected
@@ -8,7 +8,7 @@ digraph G {
                     <table border="3" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>Foo        </b></td></tr><hr/><tr><td align="left">id: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> GET</font></td></tr></table>>];
 "Foo::Bar" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  >
+                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>Bar        </b></td></tr><hr/><tr><td align="left">id: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> GET</font></td></tr></table>>];
 "Foo" -> "Foo::Bar" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 "Linking" [label=<

--- a/models/multi/testdata/swagger.expected
+++ b/models/multi/testdata/swagger.expected
@@ -62,6 +62,9 @@ paths:
                 items:
                   type: object
                   properties:
+                    id:
+                      type: integer
+                      format: int32
                     status:
                       $ref: '#/components/schemas/StandardError'
     patch:
@@ -87,6 +90,9 @@ paths:
                 items:
                   type: object
                   properties:
+                    id:
+                      type: integer
+                      format: int32
                     status:
                       $ref: '#/components/schemas/StandardError'
     delete:
@@ -116,6 +122,9 @@ paths:
                 items:
                   type: object
                   properties:
+                    id:
+                      type: integer
+                      format: int32
                     status:
                       $ref: '#/components/schemas/StandardError'
     get:
@@ -367,4 +376,3 @@ components:
             left off.
 
             When "after" is  null, there are no more records to fetch.
-

--- a/models/namespaces/testdata/dotviz.expected
+++ b/models/namespaces/testdata/dotviz.expected
@@ -8,14 +8,14 @@ digraph G {
                     <table border="3" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>A        </b></td></tr><hr/><tr><td align="left">id: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> GET PUT POST</font></td></tr></table>>];
 "A::Suba" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  >
+                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>Suba        </b></td></tr><hr/><tr><td align="left">id: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> GET PUT POST</font></td></tr></table>>];
 "A" -> "A::Suba" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 "B" [label=<
                     <table border="3" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>B        </b></td></tr><hr/><tr><td align="left">id: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> GET PUT POST</font></td></tr></table>>];
 "B::Subb" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  >
+                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>Subb        </b></td></tr><hr/><tr><td align="left">id: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> GET PUT POST</font></td></tr></table>>];
 "B" -> "B::Subb" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 }

--- a/models/request/testdata/dotviz.expected
+++ b/models/request/testdata/dotviz.expected
@@ -8,15 +8,15 @@ digraph G {
                     <table border="3" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>UploadRequest        </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="left">name: string</td></tr><tr><td align="left">status: UploadRequestStatusEnum</td></tr><tr><td align="left">client: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> POST GET MULTIGET name</font></td></tr></table>>];
 "UploadRequest::Status" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  >
+                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>Status        </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="left">recordsProcessed: int</td></tr><tr><td align="left">completed: boolean</td></tr><tr><td align="right"><font color="#0000ff" point-size="8">singleton  GET</font></td></tr></table>>];
 "UploadRequest" -> "UploadRequest::Status" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 "UploadRequest::RecordSet" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  >
+                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>RecordSet        </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="left">company: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> GET POST</font></td></tr></table>>];
 "UploadRequest" -> "UploadRequest::RecordSet" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 "UploadRequest::RecordSet::Deep" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  >
+                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>Deep        </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="left">company: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> GET POST</font></td></tr></table>>];
 "UploadRequest::RecordSet" -> "UploadRequest::RecordSet::Deep" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 "Record" [label=<

--- a/models/resourcelike-attribute/testdata/dotviz.expected
+++ b/models/resourcelike-attribute/testdata/dotviz.expected
@@ -8,7 +8,7 @@ node [shape=none];
 <table border="3" cellborder="0" cellspacing="1" style='rounded' bgcolor='#ffffcc'>
 <tr><td><b>UpperResource </b></td></tr><hr/><tr><td align="left">id: string</td></tr><tr><td align="left">subresource: LowerResource</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> GET</font></td></tr></table>>];
 "UpperResource::LowerResource" [label=<
-<table border="1" cellborder="0" cellspacing="1" style='rounded' >
+<table border="1" cellborder="0" cellspacing="1" style='rounded' bgcolor='#ffffcc'>
 <tr><td><b>LowerResource </b></td></tr><hr/><tr><td align="left">name: string</td></tr></table>>];
 "UpperResource" -> "UpperResource::LowerResource" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 }

--- a/models/simple-resource/testdata/dotviz.expected
+++ b/models/simple-resource/testdata/dotviz.expected
@@ -14,11 +14,11 @@ digraph G {
                     <table border="3" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>Foo        </b></td></tr><hr/><tr><td align="left">a: int</td></tr><tr><td align="left">b: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8">singleton  PUT GET</font></td></tr></table>>];
 "Foo::Subfoo" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  >
+                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>Subfoo        </b></td></tr><hr/><tr><td align="left">id: string</td></tr></table>>];
 "Foo" -> "Foo::Subfoo" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 "Foo::Subfoo::Subsubfoo" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  >
+                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>Subsubfoo        </b></td></tr><hr/><tr><td align="left">id: string</td></tr></table>>];
 "Foo::Subfoo" -> "Foo::Subfoo::Subsubfoo" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 "Bar" [label=<

--- a/models/singleton/testdata/dotviz.expected
+++ b/models/singleton/testdata/dotviz.expected
@@ -8,14 +8,14 @@ digraph G {
                     <table border="3" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>Resource        </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="left">name: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> POST GET</font></td></tr></table>>];
 "Resource::Metadata" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  >
+                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>Metadata        </b></td></tr><hr/><tr><td align="left">info: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8">singleton  PUT GET</font></td></tr></table>>];
 "Resource" -> "Resource::Metadata" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 "SingletonResource" [label=<
                     <table border="3" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>SingletonResource        </b></td></tr><hr/><tr><td align="left">name: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8">singleton  PUT GET</font></td></tr></table>>];
 "SingletonResource::PostableSingletonSub" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  >
+                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>PostableSingletonSub        </b></td></tr><hr/><tr><td align="left">info: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8">singleton  POST PUT GET</font></td></tr></table>>];
 "SingletonResource" -> "SingletonResource::PostableSingletonSub" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 "PostableSingletonResource" [label=<

--- a/models/table/testdata/dotviz.expected
+++ b/models/table/testdata/dotviz.expected
@@ -5,7 +5,7 @@ digraph G {
         node [shape=none];
         
 "Table::Column" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  >
+                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>Column        </b></td></tr><hr/><tr><td align="left">id: string</td></tr><tr><td align="left">name: string</td></tr><tr><td align="left">type: ColumnTypeEnum</td></tr><tr><td align="left">enumerated: boolean</td></tr><tr><td align="left">values: string[1..]</td></tr><tr><td align="left">createdAt: datetime (out)</td></tr><tr><td align="left">updatedAt: datetime (out)</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> GET POST MULTIGET PUT</font></td></tr></table>>];
 "Table" -> "Table::Column" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 "Table::Column::Disable" [label=<

--- a/models/upversion/testdata/dotviz.expected
+++ b/models/upversion/testdata/dotviz.expected
@@ -14,7 +14,7 @@ digraph G {
                     <table border="3" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>v2/ResourceB        </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="left">totalSize: int</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> POST GET</font></td></tr></table>>];
 "v2/ResourceB::Sub" [label=<
-                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  >
+                    <table border="1" cellborder="0" cellspacing="1" style='rounded'  bgcolor='#ffffcc'>
                     <tr><td><b>Sub        </b></td></tr><hr/><tr><td align="left">id: int</td></tr><tr><td align="left">name: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> POST GET</font></td></tr></table>>];
 "v2/ResourceB" -> "v2/ResourceB::Sub" [dir="back" arrowtail="ediamond" label=< <font point-size="8">subresource</font> >];
 "ResourceA" -> "ResourceB" [label=< <font point-size="8"> bId</font> > arrowhead="vee"];

--- a/src/gendotviz.ts
+++ b/src/gendotviz.ts
@@ -60,6 +60,7 @@ export default class DotvizGen extends BaseGen {
             const bgcolor = [
                 "request-resource",
                 "asset-resource",
+                "subresource",
                 "resource",
                 "configuration-resource"
             ].includes(def.type)

--- a/src/genswagger.ts
+++ b/src/genswagger.ts
@@ -472,17 +472,7 @@ export default class SwagGen extends BaseGen {
         if (ops.multiput) {
             const content = {
                 "application/json": {
-                    schema: {
-                        type: "array",
-                        items: {
-                            type: "object",
-                            properties: {
-                                status: {
-                                    $ref: "#/components/schemas/StandardError"
-                                }
-                            }
-                        }
-                    }
+                    schema: this.getMultiStatusSchema(el)
                 }
             }
             const responses: { [code: number]: any } = {
@@ -494,10 +484,10 @@ export default class SwagGen extends BaseGen {
             }
 
             this.formErrors(ops.multiput, responses)
-            let operationId = this.formOperationId(el, Verbs.MULTIPUT);
+            const operationId = this.formOperationId(el, Verbs.MULTIPUT);
             path.put = {
                 tags: [tagKeys[unique]],
-                operationId: operationId,
+                operationId,
                 description: this.translateDoc(ops.multiput.comment),
                 summary: ops.multiput.summary || operationId,
                 requestBody: {
@@ -528,17 +518,7 @@ export default class SwagGen extends BaseGen {
         if (ops.multipatch) {
             const content = {
                 "application/json": {
-                    schema: {
-                        type: "array",
-                        items: {
-                            type: "object",
-                            properties: {
-                                status: {
-                                    $ref: "#/components/schemas/StandardError"
-                                }
-                            }
-                        }
-                    }
+                    schema: this.getMultiStatusSchema(el)
                 }
             }
             const responses: { [code: number]: any } = {
@@ -549,10 +529,10 @@ export default class SwagGen extends BaseGen {
             }
 
             this.formErrors(ops.multipatch, responses)
-            let operationId = this.formOperationId(el, Verbs.MULTIPATCH);
+            const operationId = this.formOperationId(el, Verbs.MULTIPATCH);
             path.patch = {
                 tags: [tagKeys[unique]],
-                operationId: operationId,
+                operationId,
                 description: this.translateDoc(ops.multipatch.comment),
                 summary: ops.multipatch.summary || operationId,
                 requestBody: {
@@ -583,17 +563,7 @@ export default class SwagGen extends BaseGen {
         if (ops.multidelete) {
             const content = {
                 "application/json": {
-                    schema: {
-                        type: "array",
-                        items: {
-                            type: "object",
-                            properties: {
-                                status: {
-                                    $ref: "#/components/schemas/StandardError"
-                                }
-                            }
-                        }
-                    }
+                    schema: this.getMultiStatusSchema(el)
                 }
             }
             const responses: { [code: number]: any } = {
@@ -708,6 +678,27 @@ export default class SwagGen extends BaseGen {
             }
             if (gparams.length) {
                 path.get.parameters = gparams
+            }
+        }
+    }
+
+    /**
+     * Gets the multistatus schema for a resource. Applicable to MULTIPOST, MULTIDELETE, MULTIPATCH, and MULTIPUT
+     * @param el resource with multi http-verbage
+     * @returns multistatus payload schema
+     * @private
+     */
+    private getMultiStatusSchema(el: IResourceLike) {
+        return {
+            type: "array",
+            items: {
+                type: "object",
+                properties: {
+                    id: this.addType(this.extractId(el), {}, false),
+                    status: {
+                        $ref: "#/components/schemas/StandardError"
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
When using all multiverbs besides `MULTIPOST` don't return an `id` in the payload nested status objects. This is to fix that to make it synonymous with `MULTIPOST`. Additionally, I feel `subresource` instances should receive the same background as `resource` instances in the dotviz diagrams to differentiate them from the less significant `structure` instances.