### PR TITLE
Feature/devdl 408 input modifier

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -410,7 +410,9 @@ The following modifiers can be placed after the attribute type to indicate that 
 -   no modifier
     -   The default is that the field is included for POST and GET
 -   mutable
-    -   The field is included also for PUT and PATCH
+    - The field is included also for PUT and PATCH
+-   input
+    - The field is included in the request body but not the response body for CU operations (CRUD)
 -   output
     -   The field is only included for GET
 -   flag

--- a/models/authorization/testdata/parsed.expected
+++ b/models/authorization/testdata/parsed.expected
@@ -43,6 +43,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -71,6 +72,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -99,6 +101,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -132,6 +135,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -160,6 +164,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -236,6 +241,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -291,6 +297,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -355,6 +362,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -383,6 +391,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -411,6 +420,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": true,
               "optionalPost": false,
@@ -476,6 +486,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -504,6 +515,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -532,6 +544,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -671,6 +684,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -700,6 +714,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -729,6 +744,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,

--- a/models/checkrules/testdata/parsed.expected
+++ b/models/checkrules/testdata/parsed.expected
@@ -68,6 +68,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -96,6 +97,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -124,6 +126,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -152,6 +155,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -211,6 +215,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -239,6 +244,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -299,6 +305,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -327,6 +334,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -390,6 +398,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -418,6 +427,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -481,6 +491,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -509,6 +520,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -570,6 +582,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -618,6 +631,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -674,6 +688,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -703,6 +718,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -732,6 +748,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,

--- a/models/complex-resource/testdata/parsed.expected
+++ b/models/complex-resource/testdata/parsed.expected
@@ -49,6 +49,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -77,6 +78,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -105,6 +107,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -133,6 +136,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -161,6 +165,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -190,6 +195,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -219,6 +225,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -251,6 +258,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -279,6 +287,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -361,6 +370,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -389,6 +399,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -432,6 +443,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -460,6 +472,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -601,6 +614,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -632,6 +646,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": true,
               "optional": false,
               "optionalPost": false,
@@ -660,6 +675,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -741,6 +757,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -770,6 +787,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -802,6 +820,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -831,6 +850,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": true,
               "optionalPost": false,
@@ -863,6 +883,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -891,6 +912,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -934,6 +956,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": true,
               "optional": false,
               "optionalPost": false,
@@ -962,6 +985,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1021,6 +1045,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1067,6 +1092,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1114,6 +1140,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1167,6 +1194,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1231,6 +1259,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1260,6 +1289,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1289,6 +1319,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1369,6 +1400,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1398,6 +1430,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1427,6 +1460,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,

--- a/models/direct2dist/testdata/parsed.expected
+++ b/models/direct2dist/testdata/parsed.expected
@@ -128,6 +128,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -159,6 +160,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -188,6 +190,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -217,6 +220,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -249,6 +253,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -278,6 +283,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -307,6 +313,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -336,6 +343,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -365,6 +373,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": true,
               "optionalPost": false,
@@ -393,6 +402,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -422,6 +432,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -451,6 +462,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -480,6 +492,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -509,6 +522,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -538,6 +552,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -608,6 +623,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -664,6 +680,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -770,6 +787,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -798,6 +816,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -840,6 +859,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -882,6 +902,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -910,6 +931,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": true,
               "optionalPost": false,
@@ -952,6 +974,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -980,6 +1003,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1022,6 +1046,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1050,6 +1075,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": true,
               "optionalPost": false,
@@ -1092,6 +1118,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1137,6 +1164,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1166,6 +1194,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1195,6 +1224,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1237,6 +1267,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1265,6 +1296,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1307,6 +1339,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1352,6 +1385,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1409,6 +1443,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1438,6 +1473,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1467,6 +1503,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,

--- a/models/distribution/testdata/parsed.expected
+++ b/models/distribution/testdata/parsed.expected
@@ -44,6 +44,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -72,6 +73,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -140,6 +142,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -168,6 +171,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -196,6 +200,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -269,6 +274,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -297,6 +303,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -328,6 +335,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -358,6 +366,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -434,6 +443,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -464,6 +474,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -506,6 +517,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -602,6 +614,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -630,6 +643,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -658,6 +672,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -688,6 +703,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -718,6 +734,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -748,6 +765,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -779,6 +797,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -851,6 +870,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -879,6 +899,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -907,6 +928,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -949,6 +971,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -977,6 +1000,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1005,6 +1029,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1071,6 +1096,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1099,6 +1125,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1165,6 +1192,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1193,6 +1221,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1221,6 +1250,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1362,6 +1392,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1391,6 +1422,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1420,6 +1452,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,

--- a/models/eventing/testdata/parsed.expected
+++ b/models/eventing/testdata/parsed.expected
@@ -75,6 +75,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -103,6 +104,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -171,6 +173,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -199,6 +202,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -227,6 +231,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": true,
               "optionalPost": false,
@@ -299,6 +304,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -330,6 +336,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -389,6 +396,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -420,6 +428,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -481,6 +490,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -512,6 +522,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -542,6 +553,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -575,6 +587,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -595,6 +608,7 @@
             "linked": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalGet": false,
@@ -667,6 +681,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -697,6 +712,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -778,6 +794,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -806,6 +823,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -965,6 +983,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -993,6 +1012,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1059,6 +1079,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1087,6 +1108,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1115,6 +1137,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1144,6 +1167,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1172,6 +1196,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1204,6 +1229,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1235,6 +1261,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1332,6 +1359,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1378,6 +1406,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1406,6 +1435,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1434,6 +1464,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1462,6 +1493,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1490,6 +1522,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1565,6 +1598,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1593,6 +1627,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1680,6 +1715,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1710,6 +1746,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1738,6 +1775,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1801,6 +1839,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1829,6 +1868,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1901,6 +1941,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1929,6 +1970,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1960,6 +2002,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -2013,6 +2056,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -2042,6 +2086,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -2071,6 +2116,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -2151,6 +2197,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -2180,6 +2227,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -2209,6 +2257,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,

--- a/models/file/testdata/parsed.expected
+++ b/models/file/testdata/parsed.expected
@@ -134,6 +134,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -162,6 +163,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -228,6 +230,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -256,6 +259,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -284,6 +288,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -313,6 +318,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -341,6 +347,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -373,6 +380,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -404,6 +412,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -501,6 +510,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -547,6 +557,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -575,6 +586,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -603,6 +615,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -631,6 +644,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -659,6 +673,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -734,6 +749,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -762,6 +778,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -849,6 +866,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -879,6 +897,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -907,6 +926,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -970,6 +990,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -998,6 +1019,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1070,6 +1092,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1098,6 +1121,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1129,6 +1153,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1182,6 +1207,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1211,6 +1237,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1240,6 +1267,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,

--- a/models/imported-subresources/project_A/testdata/parsed.expected
+++ b/models/imported-subresources/project_A/testdata/parsed.expected
@@ -39,6 +39,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -70,6 +71,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -156,6 +158,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -201,6 +204,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -229,6 +233,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -286,6 +291,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -315,6 +321,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -344,6 +351,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -424,6 +432,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -453,6 +462,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -482,6 +492,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,

--- a/models/input-resource/api.reslang
+++ b/models/input-resource/api.reslang
@@ -1,0 +1,6 @@
+
+"This is the description of the API"
+namespace {
+    title "A simple resource API"
+    version 0.1.2
+}

--- a/models/input-resource/diagrams.reslang
+++ b/models/input-resource/diagrams.reslang
@@ -1,0 +1,5 @@
+
+diagram main {
+    /include
+        resources.reslang
+}

--- a/models/input-resource/resources.reslang
+++ b/models/input-resource/resources.reslang
@@ -1,0 +1,16 @@
+
+// A garage is a place to store cars
+"This is a description of a garage"
+resource InputResource {
+	// simple id
+	id: string query min-length:10 max-length: 300
+	requestedBy: string input
+
+	/operations
+		"Actual PUT comment"
+		// this is a PUT comment
+		PUT
+		// this is a POST comment
+		"Actual POST comment"
+		POST GET DELETE MULTIGET
+}

--- a/models/input-resource/testdata/asyncapi.expected
+++ b/models/input-resource/testdata/asyncapi.expected
@@ -1,0 +1,1 @@
+Error: No events are listed in the specification

--- a/models/input-resource/testdata/dotviz.expected
+++ b/models/input-resource/testdata/dotviz.expected
@@ -1,0 +1,10 @@
+digraph G {
+graph [fontname = "helvetica"];
+node [fontname = "helvetica"];
+edge [fontname = "helvetica"];
+node [shape=none];
+
+"InputResource" [label=<
+<table border="3" cellborder="0" cellspacing="1" style='rounded' bgcolor='#ffffcc'>
+<tr><td><b>InputResource </b></td></tr><hr/><tr><td align="left">id: string</td></tr><tr><td align="left">requestedBy: string</td></tr><tr><td align="right"><font color="#0000ff" point-size="8"> PUT POST GET DELETE MULTIGET id</font></td></tr></table>>];
+}

--- a/models/input-resource/testdata/jsonschema.expected
+++ b/models/input-resource/testdata/jsonschema.expected
@@ -1,0 +1,67 @@
+{
+  "$id": "https://schemas.liveramp.com/noroot",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "InputResourceInput": {
+      "description": "This is a description of a garage",
+      "properties": {
+        "requestedBy": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "requestedBy"
+      ],
+      "type": "object"
+    },
+    "InputResourceMultiResponse": {
+      "properties": {
+        "inputResources": {
+          "description": "Array of retrieved InputResources",
+          "items": {
+            "$ref": "#/definitions/InputResourceOutput"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "InputResourceOutput": {
+      "description": "This is a description of a garage",
+      "properties": {
+        "id": {
+          "maxLength": 300,
+          "minLength": 10,
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object"
+    },
+    "StandardError": {
+      "properties": {
+        "errorCode": {
+          "description": "Service specific error code, more granular",
+          "type": "string"
+        },
+        "httpStatus": {
+          "description": "HTTP error status code for this problem",
+          "format": "int32",
+          "type": "integer"
+        },
+        "message": {
+          "description": "General, human readable error message",
+          "type": "string"
+        }
+      },
+      "required": [
+        "httpStatus",
+        "errorCode",
+        "message"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/models/input-resource/testdata/parsed.expected
+++ b/models/input-resource/testdata/parsed.expected
@@ -1,0 +1,307 @@
+[
+  {
+    "definitions": [],
+    "diagrams": [],
+    "docs": [],
+    "imports": [],
+    "namespace": [
+      {
+        "category": "namespace",
+        "comment": "This is the description of the API",
+        "title": "A simple resource API",
+        "version": "0.1.2"
+      }
+    ],
+    "servers": [],
+    "tags": []
+  },
+  {
+    "definitions": [],
+    "diagrams": [
+      {
+        "category": "diagram",
+        "diagram": "main",
+        "groups": [],
+        "include": [
+          {
+            "module": "resources",
+            "name": "resources.reslang",
+            "parentName": "",
+            "parentShort": "",
+            "parents": [],
+            "short": "reslang"
+          }
+        ]
+      }
+    ],
+    "docs": [],
+    "imports": [],
+    "namespace": [],
+    "servers": [],
+    "tags": []
+  },
+  {
+    "definitions": [
+      {
+        "attributes": [
+          {
+            "constraints": {
+              "maxLength": 300,
+              "minLength": 10
+            },
+            "full": false,
+            "inline": false,
+            "linked": false,
+            "modifiers": {
+              "flag": false,
+              "input": false,
+              "mutable": false,
+              "nullable": false,
+              "optional": false,
+              "optionalGet": false,
+              "optionalPost": false,
+              "optionalPut": false,
+              "output": false,
+              "query": true,
+              "queryonly": false,
+              "representation": false
+            },
+            "name": "id",
+            "stringMap": false,
+            "type": {
+              "name": "string",
+              "parentName": "",
+              "parentShort": "",
+              "parents": [],
+              "short": "string"
+            }
+          },
+          {
+            "constraints": {},
+            "full": false,
+            "inline": false,
+            "linked": false,
+            "modifiers": {
+              "flag": false,
+              "input": true,
+              "mutable": false,
+              "nullable": false,
+              "optional": false,
+              "optionalGet": false,
+              "optionalPost": false,
+              "optionalPut": false,
+              "output": false,
+              "query": false,
+              "queryonly": false,
+              "representation": false
+            },
+            "name": "requestedBy",
+            "stringMap": false,
+            "type": {
+              "name": "string",
+              "parentName": "",
+              "parentShort": "",
+              "parents": [],
+              "short": "string"
+            }
+          }
+        ],
+        "category": "definition",
+        "comment": "This is a description of a garage",
+        "file": "resources.reslang",
+        "future": false,
+        "kind": "resource-like",
+        "name": "InputResource",
+        "namespace": "",
+        "operations": [
+          {
+            "comment": "Actual PUT comment",
+            "errors": [],
+            "operation": "PUT",
+            "options": [],
+            "summary": ""
+          },
+          {
+            "comment": "Actual POST comment",
+            "errors": [],
+            "operation": "POST",
+            "options": [],
+            "summary": ""
+          },
+          {
+            "errors": [],
+            "operation": "GET",
+            "options": [],
+            "summary": ""
+          },
+          {
+            "errors": [],
+            "operation": "DELETE",
+            "options": [],
+            "summary": ""
+          },
+          {
+            "errors": [],
+            "operation": "MULTIGET",
+            "options": [],
+            "summary": ""
+          }
+        ],
+        "parentName": "",
+        "parentShort": "",
+        "parents": [],
+        "secondary": false,
+        "short": "InputResource",
+        "singleton": false,
+        "type": "resource"
+      }
+    ],
+    "diagrams": [],
+    "docs": [],
+    "imports": [],
+    "namespace": [],
+    "servers": [],
+    "tags": []
+  },
+  {
+    "definitions": [
+      {
+        "attributes": [
+          {
+            "comment": "HTTP error status code for this problem",
+            "constraints": {},
+            "full": false,
+            "inline": false,
+            "linked": false,
+            "modifiers": {
+              "flag": false,
+              "input": false,
+              "mutable": false,
+              "nullable": false,
+              "optional": false,
+              "optionalGet": false,
+              "optionalPost": false,
+              "optionalPut": false,
+              "output": false,
+              "query": false,
+              "queryonly": false,
+              "representation": false
+            },
+            "name": "httpStatus",
+            "stringMap": false,
+            "type": {
+              "name": "int",
+              "parentName": "",
+              "parentShort": "",
+              "parents": [],
+              "short": "int"
+            }
+          },
+          {
+            "comment": "Service specific error code, more granular",
+            "constraints": {},
+            "full": false,
+            "inline": false,
+            "linked": false,
+            "modifiers": {
+              "flag": false,
+              "input": false,
+              "mutable": false,
+              "nullable": false,
+              "optional": false,
+              "optionalGet": false,
+              "optionalPost": false,
+              "optionalPut": false,
+              "output": false,
+              "query": false,
+              "queryonly": false,
+              "representation": false
+            },
+            "name": "errorCode",
+            "stringMap": false,
+            "type": {
+              "name": "string",
+              "parentName": "",
+              "parentShort": "",
+              "parents": [],
+              "short": "string"
+            }
+          },
+          {
+            "comment": "General, human readable error message",
+            "constraints": {},
+            "full": false,
+            "inline": false,
+            "linked": false,
+            "modifiers": {
+              "flag": false,
+              "input": false,
+              "mutable": false,
+              "nullable": false,
+              "optional": false,
+              "optionalGet": false,
+              "optionalPost": false,
+              "optionalPut": false,
+              "output": false,
+              "query": false,
+              "queryonly": false,
+              "representation": false
+            },
+            "name": "message",
+            "stringMap": false,
+            "type": {
+              "name": "string",
+              "parentName": "",
+              "parentShort": "",
+              "parents": [],
+              "short": "string"
+            }
+          }
+        ],
+        "category": "definition",
+        "file": "local.reslang",
+        "kind": "structure",
+        "name": "StandardError",
+        "parentName": "",
+        "parentShort": "",
+        "parents": [],
+        "secondary": false,
+        "short": "StandardError",
+        "type": "structure"
+      }
+    ],
+    "diagrams": [],
+    "docs": [],
+    "imports": [],
+    "namespace": [],
+    "servers": [],
+    "tags": []
+  },
+  {
+    "definitions": [],
+    "diagrams": [],
+    "docs": [],
+    "imports": [],
+    "namespace": [],
+    "servers": [
+      {
+        "category": "servers",
+        "events": [
+          {
+            "comment": "Production Google Pubsub server",
+            "environment": "PROD",
+            "protocol": "GOOGLE_PUBSUB",
+            "url": "https://pubsub.googleapis.com/v1/projects/liveramp-events-prod"
+          }
+        ],
+        "rest": [
+          {
+            "environment": "PROD",
+            "url": "https://api.liveramp.com"
+          }
+        ]
+      }
+    ],
+    "tags": []
+  }
+]

--- a/models/input-resource/testdata/swagger.expected
+++ b/models/input-resource/testdata/swagger.expected
@@ -1,0 +1,211 @@
+openapi: 3.0.1
+info:
+  title: A simple resource API
+  description: This is the description of the API
+  version: 0.1.2
+servers:
+  - description: ''
+    url: 'https://api.liveramp.com/input-resource'
+tags:
+  - name: InputResource
+    description: (resource)  This is a description of a garage
+paths:
+  /v1/input-resources:
+    post:
+      tags:
+        - InputResource
+      operationId: Create InputResource
+      description: Actual POST comment
+      summary: Create InputResource
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InputResourceInput'
+      responses:
+        '201':
+          description: InputResource created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    minLength: 10
+                    maxLength: 300
+    get:
+      tags:
+        - InputResource
+      operationId: Get InputResources
+      description: ''
+      summary: Get InputResources
+      responses:
+        '200':
+          description: InputResources retrieved successfully
+          headers: {}
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InputResourceMultiResponse'
+      parameters:
+        - in: query
+          name: limit
+          description: Number of InputResources to return
+          schema:
+            type: integer
+            format: int32
+            default: 10
+            minimum: 1
+            maximum: 100
+        - in: query
+          name: after
+          description: >-
+            This value is a cursor that enables continued paginated queries. Its
+            value can be found under "_pagination.after" in the previous
+            response from this endpoint.
+          schema:
+            type: string
+        - in: query
+          name: id
+          required: false
+          schema:
+            type: string
+            minLength: 10
+            maxLength: 300
+  '/v1/input-resources/{id}':
+    get:
+      tags:
+        - InputResource
+      operationId: Get InputResource
+      description: ''
+      summary: Get InputResource
+      responses:
+        '200':
+          description: InputResource retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InputResourceOutput'
+        '404':
+          description: InputResource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardError'
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            minLength: 10
+            maxLength: 300
+    put:
+      tags:
+        - InputResource
+      operationId: Modify InputResource
+      description: Actual PUT comment
+      summary: Modify InputResource
+      responses:
+        '200':
+          description: InputResource modified successfully
+        '404':
+          description: InputResource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardError'
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            minLength: 10
+            maxLength: 300
+    delete:
+      tags:
+        - InputResource
+      operationId: Delete InputResource
+      description: ''
+      summary: Delete InputResource
+      responses:
+        '200':
+          description: InputResource deleted successfully
+        '404':
+          description: InputResource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardError'
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            minLength: 10
+            maxLength: 300
+components:
+  parameters: {}
+  schemas:
+    InputResourceInput:
+      type: object
+      properties:
+        requestedBy:
+          type: string
+      required:
+        - requestedBy
+      description: This is a description of a garage
+    InputResourceOutput:
+      type: object
+      properties:
+        id:
+          type: string
+          minLength: 10
+          maxLength: 300
+      required:
+        - id
+      description: This is a description of a garage
+    InputResourceMultiResponse:
+      type: object
+      properties:
+        inputResources:
+          description: Array of retrieved InputResources
+          type: array
+          items:
+            $ref: '#/components/schemas/InputResourceOutput'
+        _pagination:
+          $ref: '#/components/schemas/InputResourceMultiResponsePagination'
+    StandardError:
+      type: object
+      properties:
+        httpStatus:
+          description: HTTP error status code for this problem
+          type: integer
+          format: int32
+        errorCode:
+          description: 'Service specific error code, more granular'
+          type: string
+        message:
+          description: 'General, human readable error message'
+          type: string
+      required:
+        - httpStatus
+        - errorCode
+        - message
+    InputResourceMultiResponsePagination:
+      type: object
+      properties:
+        after:
+          type: string
+          nullable: true
+          description: >-
+            This field is a cursor to be passed as a query parameter in
+            subsequent, paginated queries.
+
+            It allows the next request to begin from where the current request
+            left off.
+
+            When "after" is  null, there are no more records to fetch.

--- a/models/linked/testdata/parsed.expected
+++ b/models/linked/testdata/parsed.expected
@@ -68,6 +68,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -121,6 +122,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -175,6 +177,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -203,6 +206,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -234,6 +238,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -263,6 +268,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -294,6 +300,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -324,6 +331,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -357,6 +365,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -421,6 +430,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -450,6 +460,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -479,6 +490,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,

--- a/models/milkman/testdata/parsed.expected
+++ b/models/milkman/testdata/parsed.expected
@@ -43,6 +43,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -74,6 +75,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -102,6 +104,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -133,6 +136,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -161,6 +165,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -235,6 +240,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -263,6 +269,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -319,6 +326,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -347,6 +355,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -405,6 +414,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -458,6 +468,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -486,6 +497,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -514,6 +526,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -573,6 +586,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -618,6 +632,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -699,6 +714,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -728,6 +744,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -757,6 +774,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,

--- a/models/multi/testdata/parsed.expected
+++ b/models/multi/testdata/parsed.expected
@@ -68,6 +68,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -96,6 +97,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": true,
               "optional": false,
               "optionalPost": false,
@@ -127,6 +129,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -228,6 +231,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -281,6 +285,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -310,6 +315,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -339,6 +345,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,

--- a/models/multiplicity/testdata/parsed.expected
+++ b/models/multiplicity/testdata/parsed.expected
@@ -68,6 +68,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -101,6 +102,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -133,6 +135,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -165,6 +168,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -196,6 +200,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -260,6 +265,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -289,6 +295,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -318,6 +325,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,

--- a/models/namespaces/testdata/parsed.expected
+++ b/models/namespaces/testdata/parsed.expected
@@ -27,6 +27,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -92,6 +93,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -217,6 +219,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -282,6 +285,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -359,6 +363,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -388,6 +393,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -417,6 +423,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,

--- a/models/optionality/testdata/parsed.expected
+++ b/models/optionality/testdata/parsed.expected
@@ -69,6 +69,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -97,6 +98,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -125,6 +127,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": true,
               "optional": false,
               "optionalPost": true,
@@ -153,6 +156,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -181,6 +185,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": true,
               "optional": false,
               "optionalPost": false,
@@ -267,6 +272,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -296,6 +302,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -325,6 +332,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,

--- a/models/pagination/testdata/parsed.expected
+++ b/models/pagination/testdata/parsed.expected
@@ -34,6 +34,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -90,6 +91,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -146,6 +148,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -199,6 +202,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -227,6 +231,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -340,6 +345,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -369,6 +375,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -398,6 +405,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,

--- a/models/patchable/testdata/parsed.expected
+++ b/models/patchable/testdata/parsed.expected
@@ -59,6 +59,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -87,6 +88,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": true,
               "optional": true,
               "optionalPost": false,
@@ -119,6 +121,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": true,
               "optional": true,
               "optionalPost": false,
@@ -151,6 +154,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -179,6 +183,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -207,6 +212,7 @@
             "full": false,
             "modifiers": {
               "flag": true,
+              "input": false,
               "mutable": false,
               "optional": true,
               "optionalPost": false,
@@ -278,6 +284,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": true,
               "optional": true,
               "optionalPost": false,
@@ -335,6 +342,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -364,6 +372,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -393,6 +402,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,

--- a/models/polymorphism/testdata/parsed.expected
+++ b/models/polymorphism/testdata/parsed.expected
@@ -67,6 +67,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalGet": false,
@@ -95,6 +96,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalGet": false,
@@ -123,6 +125,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalGet": false,
@@ -182,6 +185,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalGet": false,
@@ -224,6 +228,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalGet": false,
@@ -252,6 +257,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": true,
               "optionalGet": false,
@@ -294,6 +300,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalGet": false,
@@ -322,6 +329,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalGet": false,
@@ -364,6 +372,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalGet": false,
@@ -392,6 +401,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": true,
               "optionalGet": false,
@@ -434,6 +444,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalGet": false,
@@ -487,6 +498,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalGet": false,
@@ -516,6 +528,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalGet": false,
@@ -545,6 +558,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalGet": false,

--- a/models/request/testdata/parsed.expected
+++ b/models/request/testdata/parsed.expected
@@ -68,6 +68,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -96,6 +97,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -124,6 +126,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -152,6 +155,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -217,6 +221,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -245,6 +250,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -273,6 +279,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -327,6 +334,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -355,6 +363,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -386,6 +395,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -446,6 +456,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -474,6 +485,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -505,6 +517,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -566,6 +579,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -594,6 +608,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -637,6 +652,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -665,6 +681,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -720,6 +737,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -748,6 +766,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -809,6 +828,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -837,6 +857,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -899,6 +920,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -927,6 +949,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -990,6 +1013,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1018,6 +1042,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1109,6 +1134,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1138,6 +1164,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -1167,6 +1194,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,

--- a/models/resourcelike-attribute/testdata/parsed.expected
+++ b/models/resourcelike-attribute/testdata/parsed.expected
@@ -25,6 +25,7 @@
             "linked": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "nullable": false,
               "optional": false,
@@ -53,6 +54,7 @@
             "linked": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "nullable": false,
               "optional": false,
@@ -108,6 +110,7 @@
             "linked": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "nullable": false,
               "optional": false,
@@ -173,6 +176,7 @@
             "linked": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "nullable": false,
               "optional": false,
@@ -202,6 +206,7 @@
             "linked": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "nullable": false,
               "optional": false,
@@ -231,6 +236,7 @@
             "linked": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "nullable": false,
               "optional": false,

--- a/models/servers/testdata/parsed.expected
+++ b/models/servers/testdata/parsed.expected
@@ -97,6 +97,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -125,6 +126,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -244,6 +246,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -273,6 +276,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -302,6 +306,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -355,6 +360,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -384,6 +390,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -413,6 +420,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,

--- a/models/simple-resource/testdata/parsed.expected
+++ b/models/simple-resource/testdata/parsed.expected
@@ -69,6 +69,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -100,6 +101,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": true,
               "optional": false,
               "optionalPost": false,
@@ -128,6 +130,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -209,6 +212,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -238,6 +242,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -270,6 +275,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -299,6 +305,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": true,
               "optionalPost": false,
@@ -331,6 +338,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -359,6 +367,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -402,6 +411,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": true,
               "optional": false,
               "optionalPost": false,
@@ -430,6 +440,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -489,6 +500,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -535,6 +547,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -582,6 +595,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -635,6 +649,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -699,6 +714,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -728,6 +744,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -757,6 +774,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,

--- a/models/singleton/testdata/parsed.expected
+++ b/models/singleton/testdata/parsed.expected
@@ -68,6 +68,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -96,6 +97,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -155,6 +157,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -215,6 +218,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -274,6 +278,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -340,6 +345,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -404,6 +410,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -433,6 +440,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -462,6 +470,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,

--- a/models/stringmaps/testdata/parsed.expected
+++ b/models/stringmaps/testdata/parsed.expected
@@ -68,6 +68,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -96,6 +97,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": true,
               "optionalPost": false,
@@ -128,6 +130,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -159,6 +162,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -187,6 +191,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": true,
               "optional": true,
               "optionalPost": false,
@@ -219,6 +224,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": true,
               "optional": false,
               "optionalPost": false,
@@ -247,6 +253,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -318,6 +325,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -360,6 +368,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -388,6 +397,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -430,6 +440,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -458,6 +469,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -486,6 +498,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -528,6 +541,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": true,
               "optionalPost": false,
@@ -560,6 +574,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -588,6 +603,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": true,
               "optionalPost": false,
@@ -620,6 +636,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -648,6 +665,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": true,
               "optionalPost": false,
@@ -694,6 +712,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": true,
               "optional": false,
               "optionalPost": false,
@@ -747,6 +766,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -776,6 +796,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -805,6 +826,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,

--- a/models/table/testdata/parsed.expected
+++ b/models/table/testdata/parsed.expected
@@ -43,6 +43,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -72,6 +73,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -103,6 +105,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -132,6 +135,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -165,6 +169,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": true,
               "optional": true,
               "optionalPost": false,
@@ -194,6 +199,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -223,6 +229,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -409,6 +416,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -482,6 +490,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -516,6 +525,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -605,6 +615,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -690,6 +701,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -718,6 +730,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -800,6 +813,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -829,6 +843,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -858,6 +873,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,

--- a/models/upversion/testdata/parsed.expected
+++ b/models/upversion/testdata/parsed.expected
@@ -68,6 +68,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -96,6 +97,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -124,6 +126,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -152,6 +155,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -205,6 +209,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -233,6 +238,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -298,6 +304,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -326,6 +333,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -385,6 +393,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -413,6 +422,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -484,6 +494,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -513,6 +524,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,
@@ -542,6 +554,7 @@
             "full": false,
             "modifiers": {
               "flag": false,
+              "input": false,
               "mutable": false,
               "optional": false,
               "optionalPost": false,

--- a/src/genbase.ts
+++ b/src/genbase.ts
@@ -616,6 +616,12 @@ Actions cannot have subresources`
                     continue
                 }
             }
+
+            // do not display input params on the responses
+            if (attr.modifiers.input && suffix === "Output") {
+                continue
+            }
+
             // if this is marked as output, suppress all other verbs
             if (attr.modifiers.output && verb !== Verbs.GET) {
                 continue

--- a/src/grammar/attributes.pegjs
+++ b/src/grammar/attributes.pegjs
@@ -55,6 +55,7 @@ modifiers = modifiers:modifiers_elem* { return Object.assign({
     "optionalPost": false,
     "optionalPut": false,
     "output": false,
+    "input": false,
     "query": false,
     "queryonly": false,
     "representation": false,
@@ -65,6 +66,7 @@ modifier =
   ( "flag"
   / "mutable"
   / "output"
+  / "input"
   / "optional-post"
   / "optional-put"
   / "optional-get"

--- a/src/tests/allmodels.ts
+++ b/src/tests/allmodels.ts
@@ -8,6 +8,7 @@ export const allModels = [
     "distribution",
     "eventing",
     "file",
+    "input-resource",
     "imported-subresources/project_A",
     "linked",
     "milkman",

--- a/src/tests/parser-default.test.ts
+++ b/src/tests/parser-default.test.ts
@@ -22,6 +22,7 @@ describe("reslang default parsing tests", () => {
                     "optionalPost": false,
                     "optionalPut": false,
                     "output": false,
+                    "input": false,
                     "query": false,
                     "queryonly": false,
                     "representation": false,

--- a/src/treetypes.ts
+++ b/src/treetypes.ts
@@ -226,6 +226,7 @@ export interface IArray {
 export interface IModifiers {
     flag: boolean
     mutable: boolean
+    input: boolean
     output: boolean
     optional: boolean
     optionalPost: boolean


### PR DESCRIPTION
Allows users to tag attributes with `input` modifier.

Fixes #246 