### PR TITLE
use shebang and shell syntax compatible with Ubuntu 22.04

### DIFF
--- a/install-reslang
+++ b/install-reslang
@@ -8,7 +8,5 @@ cd \"$BASEDIR\"
 ./src/main.ts \"\$@\"
 " > run-reslang
 chmod +x run-reslang
-yarn unlink >& /dev/null
+yarn unlink >/dev/null 2>&1
 yarn link
-
-

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env npx ts-node
+#!/usr/bin/env -S npx ts-node
 
 import clip from "clipboardy"
 import yaml from "js-yaml"


### PR DESCRIPTION
Make it possible to run reslang on Ubuntu 22.04 (my work laptop OS).

Without these, `./install-reslang` produces:

```
./install-reslang: 12: Syntax error: Bad fd number
```

And `reslang` produces:

```
/usr/bin/env: ‘npx ts-node’: No such file or directory
/usr/bin/env: use -[v]S to pass options in shebang lines
```
