### PR TITLE
feat: supports “prerelease” versions

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,3 +1,7 @@
+## 6.2.6 3/25/2024
+- The definition of version in Reslang support semver format goes something like (Major.Minor.Patch-<pre-release>).
+
+
 ## 6.2.5 2/23/2023
 - Add `required` attribute to httpHeader. Support optional HTTP request headers.
 

--- a/src/grammar/base.pegjs
+++ b/src/grammar/base.pegjs
@@ -35,7 +35,7 @@ description = "\"" _ inner:(!"\"" i:. {return i})* "\"" {
 }
 
 // version
-semver = semver:([0-9]+ "." [0-9]+ "." [0-9]+ ("-" [a-zA-Z0-9.-]+)?) { return semver.flat().flat().join(""); }
+semver = semver:([0-9]+ "." [0-9]+ "." [0-9]+ ("-" [a-zA-Z0-9.-]+)?) { return semver.flat(2).join(""); }
 
 // whitespace or comment
 _  = ([ \t\r\n]+ / comment)*

--- a/src/grammar/base.pegjs
+++ b/src/grammar/base.pegjs
@@ -35,7 +35,7 @@ description = "\"" _ inner:(!"\"" i:. {return i})* "\"" {
 }
 
 // version
-semver = semver:([0-9]+ "." [0-9]+ "." [0-9]+) { return semver.flat().join(""); }
+semver = semver:([0-9]+ "." [0-9]+ "." [0-9]+ ("-" [a-zA-Z0-9.-]+)?) { return semver.flat().flat().join(""); }
 
 // whitespace or comment
 _  = ([ \t\r\n]+ / comment)*

--- a/src/main.ts
+++ b/src/main.ts
@@ -130,7 +130,7 @@ const files = args._
 // read in the rules structure
 const rulesData = readFile(args.rulefile || LOCAL_RULES)
 const rules = JSON.parse(rulesData) as IRules
-rules.ignoreRules = args.ignorerules ? true : false
+rules.ignoreRules = !!args.ignorerules
 
 const testwrite = args.testwrite
 if (testwrite) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ import JsonSchemaGen from "./genjsonschema"
 const RULES = "rules.json"
 const LOCAL_RULES = lpath.join(__dirname, "library", RULES)
 
-export const VERSION = "v6.2.5"
+export const VERSION = "v6.2.6"
 
 // parse the cmd line
 const args = yargs


### PR DESCRIPTION
Context:
 The VMA app uses the python semver package that supports “prerelease” versions, as well as the usual Major.Minor.Patch.  The semver format goes something like Major.Minor.Patch[-prerelease_id.#] where prerelease_id is a text string - for us it’s “dev” for all of the intermediate versions we build and deploy to our DEV environment and “hotfix” for any intermediate versions that we might need to create in our PROD environment because our DEV environment has diverged too far from PROD.

